### PR TITLE
Extend LoopEnvironment abstractions to allow client select partial of environment variables

### DIFF
--- a/src/core/loop_environment/include/noelle/core/LoopEnvironmentBuilder.hpp
+++ b/src/core/loop_environment/include/noelle/core/LoopEnvironmentBuilder.hpp
@@ -37,6 +37,16 @@ public:
       uint64_t reducerCount,
       uint64_t numberOfUsers);
 
+  LoopEnvironmentBuilder(
+      LLVMContext &cxt,
+      LoopEnvironment *env,
+      std::function<bool(uint32_t variableID, bool isLiveOut)>
+          shouldThisVariableBeReduced,
+      std::function<bool(uint32_t variableID, bool isLiveOut)>
+          shouldThisVariableBeSkipped,
+      uint64_t reducerCount,
+      uint64_t numberOfUsers);
+
   LoopEnvironmentBuilder(LLVMContext &CXT,
                          const std::vector<Type *> &varTypes,
                          const std::set<uint32_t> &singleVarIDs,

--- a/src/core/loop_environment/include/noelle/core/LoopEnvironmentBuilder.hpp
+++ b/src/core/loop_environment/include/noelle/core/LoopEnvironmentBuilder.hpp
@@ -89,6 +89,7 @@ public:
 
   Value *getEnvironmentVariable(uint32_t id) const;
   uint32_t getIndexOfEnvironmentVariable(uint32_t id) const;
+  bool isIncludedEnvironmentVariable(uint32_t id) const;
   Value *getAccumulatedReducedEnvironmentVariable(uint32_t id) const;
   Value *getReducedEnvironmentVariable(uint32_t id, uint32_t reducerInd) const;
   bool hasVariableBeenReduced(uint32_t id) const;

--- a/src/core/loop_environment/src/LoopEnvironmentBuilder.cpp
+++ b/src/core/loop_environment/src/LoopEnvironmentBuilder.cpp
@@ -617,6 +617,10 @@ uint32_t LoopEnvironmentBuilder::getIndexOfEnvironmentVariable(
   return this->envIDToIndex.at(id);
 }
 
+bool LoopEnvironmentBuilder::isIncludedEnvironmentVariable(uint32_t id) const {
+  return (this->envIDToIndex.find(id) != this->envIDToIndex.end());
+}
+
 Value *LoopEnvironmentBuilder::getAccumulatedReducedEnvironmentVariable(
     uint32_t id) const {
   /*

--- a/src/core/task/include/noelle/core/Task.hpp
+++ b/src/core/task/include/noelle/core/Task.hpp
@@ -37,6 +37,13 @@ public:
   Value *getTaskInstanceID(void) const;
 
   /*
+   * Skipped environment variables
+   */
+  void addSkippedEnvironmentVariable(Value *v);
+
+  bool isSkippedEnvironmentVariable(Value *v) const;
+
+  /*
    * Live-in values.
    */
   bool isAnOriginalLiveIn(Value *v) const;
@@ -154,6 +161,8 @@ protected:
   std::unordered_map<BasicBlock *, BasicBlock *> basicBlockClones;
   std::unordered_map<Instruction *, Instruction *> instructionClones;
   std::unordered_map<Instruction *, Instruction *> instructionCloneToOriginal;
+
+  std::unordered_set<Value *> skippedEnvironmentVariables;
 
   Value *instanceIndexV;
   Value *envArg;

--- a/src/core/task/src/Task.cpp
+++ b/src/core/task/src/Task.cpp
@@ -45,6 +45,20 @@ uint32_t Task::getID(void) const {
   return this->ID;
 }
 
+void Task::addSkippedEnvironmentVariable(Value *v) {
+  assert(this->skippedEnvironmentVariables.find(v)
+             == this->skippedEnvironmentVariables.end()
+         && "Skipped environment variable is skipped already\n");
+  this->skippedEnvironmentVariables.insert(v);
+
+  return;
+}
+
+bool Task::isSkippedEnvironmentVariable(Value *v) const {
+  return this->skippedEnvironmentVariables.find(v)
+         != this->skippedEnvironmentVariables.end();
+}
+
 bool Task::isAnOriginalLiveIn(Value *v) const {
   if (this->liveInClones.find(v) == this->liveInClones.end()) {
     return false;

--- a/src/tools/doall/src/DOALL.cpp
+++ b/src/tools/doall/src/DOALL.cpp
@@ -324,6 +324,7 @@ bool DOALL::apply(LoopDependenceInfo *LDI, Heuristics *h) {
         auto sccInfo = sccManager->getSCCAttrs(scc);
         if (!sccInfo->isInductionVariableSCC()
             && sccInfo->canExecuteReducibly()) {
+          chunkerTask->addSkippedEnvironmentVariable(producer);
           return true;
         }
       }

--- a/src/tools/doall/src/DOALL.cpp
+++ b/src/tools/doall/src/DOALL.cpp
@@ -300,7 +300,38 @@ bool DOALL::apply(LoopDependenceInfo *LDI, Heuristics *h) {
 
     return true;
   };
-  this->initializeEnvironmentBuilder(LDI, isReducible);
+  auto isSkippable = [this, loopEnvironment, sccManager, chunkerTask](
+                         uint32_t id,
+                         bool isLiveOut) -> bool {
+    if (isLiveOut) {
+      return false;
+    }
+
+    /*
+     * We have a live-in variable.
+     *
+     * The initial value of the reduction variable can be skipped,
+     * which means the following conditions should all meet
+     * 1. This live-in variable only has one user, and
+     * 2. The user is a phi node, and
+     * 3. The scc contains this phi is not part of the induction variable but
+     * reducible operation
+     */
+    auto producer = loopEnvironment->getProducer(id);
+    if (producer->getNumUses() == 1) {
+      if (auto consumer = dyn_cast<PHINode>(*producer->user_begin())) {
+        auto scc = sccManager->getSCCDAG()->sccOfValue(consumer);
+        auto sccInfo = sccManager->getSCCAttrs(scc);
+        if (!sccInfo->isInductionVariableSCC()
+            && sccInfo->canExecuteReducibly()) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+  this->initializeEnvironmentBuilder(LDI, isReducible, isSkippable);
 
   /*
    * Clone loop into the single task used by DOALL

--- a/src/tools/helix/src/HELIX.cpp
+++ b/src/tools/helix/src/HELIX.cpp
@@ -304,7 +304,39 @@ void HELIX::createParallelizableTask(LoopDependenceInfo *LDI, Heuristics *h) {
 
     return false;
   };
-  this->initializeEnvironmentBuilder(LDI, isReducible);
+  auto isSkippable = [this, environment, sccManager, helixTask](
+                         uint32_t id,
+                         bool isLiveOut) -> bool {
+    if (isLiveOut) {
+      return false;
+    }
+
+    /*
+     * We have a live-in variable.
+     *
+     * The initial value of the reduction variable can be skipped,
+     * which means the following conditions should all meet
+     * 1. This live-in variable only has one user, and
+     * 2. The user is a phi node, and
+     * 3. The scc contains this phi is not part of the induction variable but
+     * reducible operation
+     */
+    auto producer = environment->getProducer(id);
+    if (producer->getNumUses() == 1) {
+      if (auto consumer = dyn_cast<PHINode>(*producer->user_begin())) {
+        auto scc = sccManager->getSCCDAG()->sccOfValue(consumer);
+        auto sccInfo = sccManager->getSCCAttrs(scc);
+        if (!sccInfo->isInductionVariableSCC()
+            && sccInfo->canExecuteReducibly()) {
+          helixTask->addSkippedEnvironmentVariable(producer);
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+  this->initializeEnvironmentBuilder(LDI, isReducible, isSkippable);
 
   /*
    * Clone the sequential loop and store the cloned instructions/basic blocks

--- a/src/tools/parallelization_technique/include/noelle/tools/ParallelizationTechnique.hpp
+++ b/src/tools/parallelization_technique/include/noelle/tools/ParallelizationTechnique.hpp
@@ -82,17 +82,24 @@ protected:
   /*
    * Loop's environment
    */
-  void initializeEnvironmentBuilder(
-      LoopDependenceInfo *LDI,
-      std::function<bool(uint32_t variableID, bool isLiveOut)>
-          shouldThisVariableBeReduced);
-
   void initializeEnvironmentBuilder(LoopDependenceInfo *LDI,
                                     std::set<uint32_t> nonReducableVars);
 
   void initializeEnvironmentBuilder(LoopDependenceInfo *LDI,
                                     std::set<uint32_t> simpleVars,
                                     std::set<uint32_t> reducableVars);
+
+  void initializeEnvironmentBuilder(
+      LoopDependenceInfo *LDI,
+      std::function<bool(uint32_t variableID, bool isLiveOut)>
+          shouldThisVariableBeReduced);
+
+  void initializeEnvironmentBuilder(
+      LoopDependenceInfo *LDI,
+      std::function<bool(uint32_t variableID, bool isLiveOut)>
+          shouldThisVariableBeReduced,
+      std::function<bool(uint32_t variableID, bool isLiveOut)>
+          shouldThisVariableBeSkipped);
 
   void initializeLoopEnvironmentUsers(void);
 

--- a/src/tools/parallelization_technique/src/ParallelizationTechnique.cpp
+++ b/src/tools/parallelization_technique/src/ParallelizationTechnique.cpp
@@ -1286,6 +1286,14 @@ void ParallelizationTechnique::adjustDataFlowToUseClones(Instruction *cloneI,
     auto opV = op.get();
 
     /*
+     * If the value is a skipped environment variable, there is nothing we need
+     * to do.
+     */
+    if (task->isSkippedEnvironmentVariable(opV)) {
+      continue;
+    }
+
+    /*
      * If the value is a constant, then there is nothing we need to do.
      */
     if (dyn_cast<Constant>(opV)) {

--- a/src/tools/parallelization_technique/src/ParallelizationTechnique.cpp
+++ b/src/tools/parallelization_technique/src/ParallelizationTechnique.cpp
@@ -199,6 +199,12 @@ void ParallelizationTechnique::populateLiveInEnvironment(
    */
   IRBuilder<> builder(this->entryPointOfParallelizedLoop);
   for (auto envID : env->getEnvIDsOfLiveInVars()) {
+    /*
+     * Skip the environment variable if it's not included in the builder
+     */
+    if (!this->envBuilder->isIncludedEnvironmentVariable(envID)) {
+      continue;
+    }
 
     /*
      * Fetch the value to store.

--- a/src/tools/parallelization_technique/src/ParallelizationTechnique.cpp
+++ b/src/tools/parallelization_technique/src/ParallelizationTechnique.cpp
@@ -43,6 +43,16 @@ uint32_t ParallelizationTechnique::getIndexOfEnvironmentVariable(
 
 void ParallelizationTechnique::initializeEnvironmentBuilder(
     LoopDependenceInfo *LDI,
+    std::set<uint32_t> nonReducableVars) {
+  std::set<uint32_t> emptySet{};
+
+  this->initializeEnvironmentBuilder(LDI, nonReducableVars, emptySet);
+
+  return;
+}
+
+void ParallelizationTechnique::initializeEnvironmentBuilder(
+    LoopDependenceInfo *LDI,
     std::set<uint32_t> simpleVars,
     std::set<uint32_t> reducableVars) {
   auto isReducable = [&reducableVars](uint32_t variableID,
@@ -61,6 +71,21 @@ void ParallelizationTechnique::initializeEnvironmentBuilder(
     LoopDependenceInfo *LDI,
     std::function<bool(uint32_t variableID, bool isLiveOut)>
         shouldThisVariableBeReduced) {
+  auto shouldThisVariableBeSkipped =
+      [](uint32_t variableID, bool isLiveOut) -> bool { return false; };
+  this->initializeEnvironmentBuilder(LDI,
+                                     shouldThisVariableBeReduced,
+                                     shouldThisVariableBeSkipped);
+
+  return;
+}
+
+void ParallelizationTechnique::initializeEnvironmentBuilder(
+    LoopDependenceInfo *LDI,
+    std::function<bool(uint32_t variableID, bool isLiveOut)>
+        shouldThisVariableBeReduced,
+    std::function<bool(uint32_t variableID, bool isLiveOut)>
+        shouldThisVariableBeSkipped) {
   assert(LDI != nullptr);
 
   /*
@@ -86,6 +111,7 @@ void ParallelizationTechnique::initializeEnvironmentBuilder(
   this->envBuilder = new LoopEnvironmentBuilder(program->getContext(),
                                                 environment,
                                                 shouldThisVariableBeReduced,
+                                                shouldThisVariableBeSkipped,
                                                 this->numTaskInstances,
                                                 this->tasks.size());
 
@@ -124,16 +150,6 @@ void ParallelizationTechnique::initializeLoopEnvironmentUsers(void) {
         "noelle.environment_variable.pointer");
     envUser->setEnvironmentArray(bitcastInst);
   }
-
-  return;
-}
-
-void ParallelizationTechnique::initializeEnvironmentBuilder(
-    LoopDependenceInfo *LDI,
-    std::set<uint32_t> nonReducableVars) {
-  std::set<uint32_t> emptySet{};
-
-  this->initializeEnvironmentBuilder(LDI, nonReducableVars, emptySet);
 
   return;
 }


### PR DESCRIPTION
## Overview
The PR adds the support to allow client to select part of environment variables. i.e, in reducible operations, the initial value, which is a live-in variable, doesn't need to be included into the task but can be later initialized with the identity value of that operation in the cloned task instead. Below is a breakdown of all the changes to different classes in NOELLE. Two clients, **DOALL** and **HELIX** has been modified to ignore the initial value while parallelized with reducible operations.

### DOALL
* public:
	* apply: add lambda isSkippable to skip the initial value of reduction variable, and let skipped variables tacked by the task

### ParallelizationTechnique
* public:
	* new constructor that takes a skippable lambda function as initial argument
	* adjustDataFlowToUseClones: skip a value if it's a skipped environment variable
	* populateLiveInEnvironment: check if an environment variable is included in the builder before creating store instruction

### LoopEnvironmentBuilder
* public:
	* new constructor that takes a skippable lambda function as initial argument
	* create method isIncludedEnvironmentVariable: return true if a environment variable is considered by the builder

### Task
* public:
	* create method isSkippedEnvironmentVariable: check if an environment variable is skipped from the client
	* create method addSkippedEnvironmentVariable: marked an environment variable to be skipped from the client
* private:
	* add unordered_set skippedEnvironmentVariables to track all skipped environmnent variables