### PR TITLE
Bugfix and new feature for metadata cleaning

### DIFF
--- a/src/core/scripts/installNOELLE.sh
+++ b/src/core/scripts/installNOELLE.sh
@@ -31,6 +31,7 @@ patchInstallDir "noelle-meta-clean" ;
 patchInstallDir "noelle-meta-pdg-clean " ;
 patchInstallDir "noelle-meta-loop-embed" ;
 patchInstallDir "noelle-meta-pdg-embed" ;
+patchInstallDir "noelle-meta-prof-clean" ;
 patchInstallDir "noelle-meta-prof-embed" ;
 patchInstallDir "noelle-prof-coverage" ;
 patchInstallDir "noelle-config" ;

--- a/src/core/scripts/noelle-meta-loop-clean
+++ b/src/core/scripts/noelle-meta-loop-clean
@@ -8,6 +8,6 @@ fi
 installDir
 
 # Remove the PDG from the bitcode
-cmdToExecute="noelle-load -load ${installDir}/lib/CleanMetadata.so -CleanMetadata -clean-loop-metadata=true -clean-prof-metadata=false -clean-pdg-metadata=false $1 -o $2" 
+cmdToExecute="noelle-load -load ${installDir}/lib/CleanMetadata.so -CleanMetadata -clean-loop-metadata=true $1 -o $2" 
 echo $cmdToExecute ;
 eval $cmdToExecute 

--- a/src/core/scripts/noelle-meta-pdg-clean
+++ b/src/core/scripts/noelle-meta-pdg-clean
@@ -8,6 +8,6 @@ fi
 installDir
 
 # Remove the PDG from the bitcode
-cmdToExecute="noelle-load -load ${installDir}/lib/CleanMetadata.so -CleanMetadata -clean-loop-metadata=false -clean-prof-metadata=false -clean-pdg-metadata=true $1 -o $2" 
+cmdToExecute="noelle-load -load ${installDir}/lib/CleanMetadata.so -CleanMetadata -clean-pdg-metadata=true $1 -o $2" 
 echo $cmdToExecute ;
 eval $cmdToExecute 

--- a/src/core/scripts/noelle-meta-prof-clean
+++ b/src/core/scripts/noelle-meta-prof-clean
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if test $# -lt 2 ; then
+  echo "USAGE: `basename $0` INPUT_BITCODE OUTPUT_BITCODE" ;
+  exit 1;
+fi
+
+installDir
+
+# Remove the PDG from the bitcode
+cmdToExecute="noelle-load -load ${installDir}/lib/CleanMetadata.so -CleanMetadata -clean-prof-metadata=true $1 -o $2" 
+echo $cmdToExecute ;
+eval $cmdToExecute 


### PR DESCRIPTION
Changes:
- Fixed previously discussed bug for noelle-meta-loop-clean and noelle-meta-pdg-clean erasing too much metadata.
- Added new command for cleaning profiler metadata. Nothing in master uses this yet but I use it on the nested parallelism, and since the metadata cleaning pass already has the code to do it I figured I'd tack it onto this.
