### PR TITLE
Bugfix for missing loop carried dependence from store to itself

### DIFF
--- a/src/core/pdg/src/PDGAnalysis.cpp
+++ b/src/core/pdg/src/PDGAnalysis.cpp
@@ -678,8 +678,8 @@ void PDGAnalysis::removeEdgesNotUsedByParSchemes(PDG *pdg) {
     }
 
     /*
-     * Check if the function of the dependence destiation cannot be reached from
-     * main.
+     * Check if the function of the dependence destination cannot be reached
+     * from main.
      */
     if (edgeIsNotLoopCarriedMemoryDependency(edge)
         || edgeIsAlongNonMemoryWritingFunctions(edge)) {

--- a/src/core/pdg/src/PDGAnalysis_memory.cpp
+++ b/src/core/pdg/src/PDGAnalysis_memory.cpp
@@ -40,14 +40,12 @@ void PDGAnalysis::iterateInstForStore(PDG *pdg,
      * Check stores.
      */
     if (auto otherStore = dyn_cast<StoreInst>(I)) {
-      if (store != otherStore) {
-        this->addEdgeFromMemoryAlias<StoreInst, StoreInst>(pdg,
-                                                           F,
-                                                           AA,
-                                                           store,
-                                                           otherStore,
-                                                           DG_DATA_WAW);
-      }
+      this->addEdgeFromMemoryAlias<StoreInst, StoreInst>(pdg,
+                                                         F,
+                                                         AA,
+                                                         store,
+                                                         otherStore,
+                                                         DG_DATA_WAW);
       continue;
     }
 

--- a/tests/regression/SingleStoreLoopCarriedDependence/test.c
+++ b/tests/regression/SingleStoreLoopCarriedDependence/test.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void print_array(int ni, int D[ni]) {
+  int i;
+  for (i = 0; i < ni; i++)
+    fprintf(stderr, "%d ", D[i]);
+  fprintf(stderr, "\n");
+}
+
+int main(int argc, char **argv) {
+  int ni = atoi(argv[1]);
+  int alpha = 2;
+
+  int *tmp = (int *)calloc(ni, sizeof(int));
+  for (int i = 0; i < ni; ++i) {
+    tmp[0] += alpha;
+  }
+
+  print_array(ni, tmp);
+  free((void *)tmp);
+  return 0;
+}


### PR DESCRIPTION
This is for the bug where a loop was being parallelized as DOALL when it should not have been.

The cause of the bug was a missing loop carried memory dependence from a store instruction to itself (the one that stores to `tmp[0]` in the new test). In the PDG analysis, potential self-edges for stores were explicitly ignored. I'm not sure why it was written that way, but I changed it to consider the relevant cases and added a new regression test.