### PR TITLE
Parallelizer: erase llvm lifetime intrinsics in modified functions

### DIFF
--- a/src/tools/parallelizer/src/Pass.cpp
+++ b/src/tools/parallelizer/src/Pass.cpp
@@ -131,6 +131,7 @@ bool Parallelizer::runOnModule(Module &M) {
    */
   auto modified = false;
   std::unordered_map<BasicBlock *, bool> modifiedBBs{};
+  std::unordered_set<Function *> modifiedFunctions;
   for (auto indexLoopPair : loopParallelizationOrder) {
     auto ldi = indexLoopPair.second;
 
@@ -180,6 +181,7 @@ bool Parallelizer::runOnModule(Module &M) {
       for (auto bb : ls->getBasicBlocks()) {
         modifiedBBs[bb] = true;
       }
+      modifiedFunctions.insert(ls->getFunction());
     }
   }
 
@@ -188,6 +190,23 @@ bool Parallelizer::runOnModule(Module &M) {
    */
   for (auto indexLoopPair : loopParallelizationOrder) {
     delete indexLoopPair.second;
+  }
+
+  /*
+   * Erase calls to intrinsics in modified functions
+   */
+  std::unordered_set<CallInst *> intrinsicCallsToRemove;
+  for (auto F : modifiedFunctions) {
+    for (auto &I : *F) {
+      if (auto callInst = dyn_cast<CallInst>(&I)) {
+        if (callInst->isLifetimeStartOrEnd()) {
+          intrinsicCallsToRemove.insert(callInst);
+        }
+      }
+    }
+  }
+  for (auto call : intrinsicCallsToRemove) {
+    call->eraseFromParent();
   }
 
   errs() << "Parallelizer: Exit\n";


### PR DESCRIPTION
Temporary fix for issues caused by disregarding semantics of LLVM lifetime intrinsic instructions