### PR TITLE
PDGAnalysis: optimization on dependence addition through getModRefInfo

### DIFF
--- a/src/core/pdg_analysis/src/PDGAnalysis_memory.cpp
+++ b/src/core/pdg_analysis/src/PDGAnalysis_memory.cpp
@@ -705,15 +705,6 @@ void PDGAnalysis::addEdgeFromFunctionModRef(PDG *pdg,
 
     } else if (rbv[1]) {
       /*
-       * Check the unique case that @otherCall and @call are the same.
-       * In this case, there is also a RAW and WAR dependence
-       */
-      if (otherCall == call) {
-        pdg->addEdge(call, otherCall)->setMemMustType(true, false, DG_DATA_RAW);
-        pdg->addEdge(call, otherCall)->setMemMustType(true, false, DG_DATA_WAR);
-      }
-
-      /*
        * @call may write a memory location that can be written by @otherCall
        * only need to add WAW data dependence from call to otherCall
        */


### PR DESCRIPTION
When querying `getModRefInfo(otherCall, call)` and get `Mod` result. If `call` is also reachable from `otherCall` and the reverse query also returns `Mod`. No matter if `(call == otherCall)`. There's only WAW data dependence from `call` to `otherCall`.

Regression test output:
```
./scripts/condor_check.sh ;
################################### REGRESSION TESTS:
  Checking the regression test results
    All tests finished
    5 new tests failed: 
	regression_124/AliasAnalysisKillFlowBug -noelle-pdg-check -noelle-verbose=3 -noelle-max-cores=8  -noelle-parallelizer-force -O1 -Xclang -disable-llvm-passes -O1
	regression_126/AliasAnalysisKillFlowBug -noelle-pdg-check -noelle-verbose=3 -noelle-max-cores=8 -noelle-disable-loop-invariant-code-motion  -noelle-parallelizer-force -O1 -Xclang -disable-llvm-passes -O1
	regression_131/AliasAnalysisKillFlowBug -noelle-pdg-check -noelle-verbose=3 -noelle-max-cores=8 -noelle-disable-dswp -noelle-disable-inliner  -noelle-parallelizer-force -O1 -Xclang -disable-llvm-passes -O1
	regression_139/AliasAnalysisKillFlowBug -noelle-pdg-check -noelle-verbose=3 -noelle-max-cores=8 -noelle-disable-enablers -noelle-disable-inliner -noelle-disable-dead -noelle-parallelizer-force -O1 -Xclang -disable-llvm-passes -O1
	regression_6/AliasAnalysisKillFlowBug -noelle-pdg-check -noelle-verbose=3 -noelle-max-cores=8 -noelle-disable-dswp  -noelle-parallelizer-force -O0 -Xclang -disable-O0-optnone -O0
    The regression tests failed


################################### UNIT TESTS:
  All unit tests succeded


################################### PERFORMANCE TESTS:
  Next are the performance tests that run slower:
    Performance degradation for DSWP_communication (from 1.2x to 0.4x)
```