### PR TITLE
Enabler: add a new enabler to make file accesses more amenable for parallelization

### DIFF
--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -1,5 +1,5 @@
 PARALLELIZER=parallelizer heuristics parallelization_technique dswp doall helix parallelization_planner
-TOOLS=pdg_stats loop_size removefunction time_saved autotuner_search_space autotuner_doall_filter
+TOOLS=pdg_stats loop_size removefunction time_saved autotuner_search_space autotuner_doall_filter input_output
 ALL=$(TOOLS) enablers deadfunctioneliminator loop_invariant_code_motion scev_simplification inliner $(PARALLELIZER) loop_stats scripts
 
 all: $(ALL)
@@ -29,6 +29,9 @@ scev_simplification:
 	cd $@ ; ../../scripts/run_me.sh
 
 inliner:
+	cd $@ ; ../../scripts/run_me.sh
+
+input_output:
 	cd $@ ; ../../scripts/run_me.sh
 
 heuristics:

--- a/src/tools/enablers/src/Enablers.cpp
+++ b/src/tools/enablers/src/Enablers.cpp
@@ -32,12 +32,6 @@ bool EnablersManager::applyEnablers(
     LoopInvariantCodeMotion &loopInvariantCodeMotion,
     SCEVSimplification &scevSimplification) {
 
-  if (auto getcFunc =
-          LDI->getLoopStructure()->getHeader()->getModule()->getFunction(
-              "getc")) {
-    getcFunc->setName("getc_unlocked");
-  }
-
   /*
    * Apply loop distribution.
    */

--- a/src/tools/enablers/src/Enablers.cpp
+++ b/src/tools/enablers/src/Enablers.cpp
@@ -32,6 +32,12 @@ bool EnablersManager::applyEnablers(
     LoopInvariantCodeMotion &loopInvariantCodeMotion,
     SCEVSimplification &scevSimplification) {
 
+  if (auto getcFunc =
+          LDI->getLoopStructure()->getHeader()->getModule()->getFunction(
+              "getc")) {
+    getcFunc->setName("getc_unlocked");
+  }
+
   /*
    * Apply loop distribution.
    */

--- a/src/tools/input_output/CMakeLists.txt
+++ b/src/tools/input_output/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Project
+cmake_minimum_required(VERSION 3.13)
+project(InputOutput)
+
+# Dependences
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/DependencesCMake.txt)
+
+# Pass
+add_subdirectory(src)
+
+# Install
+install(
+  FILES
+  DESTINATION
+  )

--- a/src/tools/input_output/src/CMakeLists.txt
+++ b/src/tools/input_output/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Sources
+set(Srcs 
+  Pass.cpp
+  InputOutput.cpp
+)
+
+# Compilation flags
+set_source_files_properties(${Srcs} PROPERTIES COMPILE_FLAGS " -std=c++17 -fPIC")
+
+# Name of the LLVM pass
+set(PassName "InputOutput")
+
+# configure LLVM 
+find_package(LLVM 9 REQUIRED CONFIG)
+
+set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/)
+
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(HandleLLVMOptions)
+include(AddLLVM)
+
+message(STATUS "LLVM_DIR IS ${LLVM_CMAKE_DIR}.")
+message(STATUS "Installation directory is ${CMAKE_INSTALL_PREFIX}.")
+
+include_directories(${LLVM_INCLUDE_DIRS} 
+  ../include
+  ./
+  ${CMAKE_INSTALL_PREFIX}/include
+  )
+
+# Declare the LLVM pass to compile
+add_llvm_library(${PassName} MODULE ${Srcs})

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2022  Simone Campanoni
+ * Copyright 2023  Tzu-Hsuan Huang, Simone Campanoni
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 - 2022  Simone Campanoni
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "noelle/core/Noelle.hpp"
+#include "InputOutput.hpp"
+
+namespace llvm::noelle {
+
+InputOutput::InputOutput() : ModulePass{ ID } {}
+
+bool InputOutput::runOnModule(Module &M) {
+  if (auto getcF = M.getFunction("getc")) {
+    getcF->setName("getc_unlocked");
+  }
+
+  return false;
+}
+
+} // namespace llvm::noelle

--- a/src/tools/input_output/src/InputOutput.hpp
+++ b/src/tools/input_output/src/InputOutput.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 - 2021  Simone Campanoni
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "noelle/core/SystemHeaders.hpp"
+
+namespace llvm::noelle {
+
+class InputOutput : public ModulePass {
+public:
+  /*
+   * Class fields
+   */
+  static char ID;
+
+  /*
+   * Methods
+   */
+  InputOutput();
+  bool doInitialization(Module &M) override;
+  bool runOnModule(Module &M) override;
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+private:
+};
+
+} // namespace llvm::noelle

--- a/src/tools/input_output/src/InputOutput.hpp
+++ b/src/tools/input_output/src/InputOutput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 - 2021  Simone Campanoni
+ * Copyright 2023  Tzu-Hsuan Huang, Simone Campanoni
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/src/tools/input_output/src/Pass.cpp
+++ b/src/tools/input_output/src/Pass.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Simone Campanoni
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "noelle/core/Noelle.hpp"
+#include "InputOutput.hpp"
+
+namespace llvm::noelle {
+
+bool InputOutput::doInitialization(Module &M) {
+  return false;
+}
+
+void InputOutput::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<Noelle>();
+  return;
+}
+
+// Next there is code to register your pass to "opt"
+char InputOutput::ID = 0;
+static RegisterPass<InputOutput> X(
+    "inputoutput",
+    "Make file accesses more amenable for parallelizations",
+    false,
+    false);
+
+// Next there is code to register your pass to "clang"
+static InputOutput *_PassMaker = NULL;
+static RegisterStandardPasses _RegPass1(PassManagerBuilder::EP_OptimizerLast,
+                                        [](const PassManagerBuilder &,
+                                           legacy::PassManagerBase &PM) {
+                                          if (!_PassMaker) {
+                                            PM.add(_PassMaker =
+                                                       new InputOutput());
+                                          }
+                                        }); // ** for -Ox
+static RegisterStandardPasses _RegPass2(
+    PassManagerBuilder::EP_EnabledOnOptLevel0,
+    [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
+      if (!_PassMaker) {
+        PM.add(_PassMaker = new InputOutput());
+      }
+    }); // ** for -O0
+
+} // namespace llvm::noelle

--- a/src/tools/input_output/src/Pass.cpp
+++ b/src/tools/input_output/src/Pass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Simone Campanoni
+ * Copyright 2023  Tzu-Hsuan Huang, Simone Campanoni
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/src/tools/scripts/installNOELLETools.sh
+++ b/src/tools/scripts/installNOELLETools.sh
@@ -32,6 +32,7 @@ patchInstallDir "noelle-pre" ;
 patchInstallDir "noelle-deadcode" ;
 patchInstallDir "noelle-rm-function" ;
 patchInstallDir "noelle-loopsize" ;
+patchInstallDir "noelle-io" ;
 patchInstallDir "noelle-fixedpoint" ;
 patchInstallDir "noelle-pdg-stats" ;
 patchInstallDir "noelle-loop-stats" ;

--- a/src/tools/scripts/noelle-io
+++ b/src/tools/scripts/noelle-io
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+installDir
+
+bcFile="$@" ;
+
+# Set the command to execute
+cmdToExecute="noelle-load -load ${installDir}/lib/InputOutput.so -inputoutput ${bcFile} -o ${bcFile}"
+echo $cmdToExecute ;
+
+# Execute the command
+eval $cmdToExecute ;

--- a/src/tools/scripts/noelle-pre
+++ b/src/tools/scripts/noelle-pre
@@ -52,6 +52,11 @@ cmdToExecute="noelle-simplification $notOptions -o $notOptions"
 echo $cmdToExecute ;
 eval $cmdToExecute ;
 
+# Make file accesses more amenable for parallelization
+cmdToExecute="noelle-io $notOptions"
+echo $cmdToExecute ;
+eval $cmdToExecute ;
+
 # Inline functions
 cmdToExecute="noelle-inline $notOptions \"-noelle-inliner-verbose=1 $options\""
 echo $cmdToExecute ;


### PR DESCRIPTION
- Added a new enabler, `noelle-io`, to make file accesses more amenable for parallelization.
- Currently, the only transformation implemented in `noelle-io` is replacing all `getc` with `getc_unlocked`.
	- Since we will handle the synchronization manually, using the unlocked version of `getc` is safe without acquiring and releasing locks for files in runtime.
- The new enabler is tested on all test cases (https://github.com/arcana-lab/noelle/tree/master/tests) and benchmarks from https://github.com/arcana-lab/noelleGym.
- TODO: transformations that replace other `stdio` having an implicit locking mechanism.

![MiBench](https://github.com/arcana-lab/noelle/assets/31137536/142328e8-ac48-4882-816f-cde04d04a1e5)
![NAS](https://github.com/arcana-lab/noelle/assets/31137536/bd494fa6-5dca-4c14-ac57-3245367ba89a)
![PARSEC](https://github.com/arcana-lab/noelle/assets/31137536/43953406-4de9-4f18-8815-c7b4de3c0879)
![PolyBench](https://github.com/arcana-lab/noelle/assets/31137536/3d44ba25-f8cd-4ceb-9c6f-da14d9d3772c)


