### PR TITLE
Enabler: add transformations that replace more stdio having an implicit locking mechanism

### DIFF
--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -35,6 +35,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
   { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
   { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
+  { "vprintf", "vprintf_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,17 +27,17 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fclose", "fclose_unlocked" },     { "fflush", "fflush_unlocked" },
-  { "fgetc", "fgetc_unlocked" },       { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" },       { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" },       { "fprintf", "fprintf_unlocked" },
-  { "fscanf", "fscanf_unlocked" },     { "getc", "getc_unlocked" },
-  { "getchar", "getchar_unlocked" },   { "putc", "putc_unlocked" },
-  { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
-  { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
-  { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
-  { "vprintf", "vprintf_unlocked" },   { "vscanf", "vscanf_unlocked" },
-  { "fwrite", "fwrite_unlocked" },
+  { "clearerr", "clearerr_unlocked" }, { "fclose", "fclose_unlocked" },
+  { "fflush", "fflush_unlocked" },     { "fgetc", "fgetc_unlocked" },
+  { "fgets", "fgets_unlocked" },       { "fputc", "fputc_unlocked" },
+  { "fputs", "fputs_unlocked" },       { "fread", "fread_unlocked" },
+  { "fprintf", "fprintf_unlocked" },   { "fscanf", "fscanf_unlocked" },
+  { "getc", "getc_unlocked" },         { "getchar", "getchar_unlocked" },
+  { "putc", "putc_unlocked" },         { "putchar", "putchar_unlocked" },
+  { "printf", "printf_unlocked" },     { "scanf", "scanf_unlocked" },
+  { "ungetc", "ungetc_unlocked" },     { "vfprintf", "vfprintf_unlocked" },
+  { "vfscanf", "vfscanf_unlocked" },   { "vprintf", "vprintf_unlocked" },
+  { "vscanf", "vscanf_unlocked" },     { "fwrite", "fwrite_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,16 +27,17 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fclose", "fclose_unlocked" },   { "fgetc", "fgetc_unlocked" },
-  { "fgets", "fgets_unlocked" },     { "fputc", "fputc_unlocked" },
-  { "fputs", "fputs_unlocked" },     { "fread", "fread_unlocked" },
-  { "fprintf", "fprintf_unlocked" }, { "fscanf", "fscanf_unlocked" },
-  { "getc", "getc_unlocked" },       { "getchar", "getchar_unlocked" },
-  { "putc", "putc_unlocked" },       { "putchar", "putchar_unlocked" },
-  { "printf", "printf_unlocked" },   { "scanf", "scanf_unlocked" },
-  { "ungetc", "ungetc_unlocked" },   { "vfprintf", "vfprintf_unlocked" },
-  { "vfscanf", "vfscanf_unlocked" }, { "vprintf", "vprintf_unlocked" },
-  { "vscanf", "vscanf_unlocked" },   { "fwrite", "fwrite_unlocked" },
+  { "fclose", "fclose_unlocked" },     { "fflush", "fflush_unlocked" },
+  { "fgetc", "fgetc_unlocked" },       { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" },       { "fputs", "fputs_unlocked" },
+  { "fread", "fread_unlocked" },       { "fprintf", "fprintf_unlocked" },
+  { "fscanf", "fscanf_unlocked" },     { "getc", "getc_unlocked" },
+  { "getchar", "getchar_unlocked" },   { "putc", "putc_unlocked" },
+  { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
+  { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
+  { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
+  { "vprintf", "vprintf_unlocked" },   { "vscanf", "vscanf_unlocked" },
+  { "fwrite", "fwrite_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -31,6 +31,10 @@ bool InputOutput::runOnModule(Module &M) {
     getcF->setName("fgetc_unlocked");
   }
 
+  if (auto getcF = M.getFunction("fgets")) {
+    getcF->setName("fgets_unlocked");
+  }
+
   if (auto getcF = M.getFunction("getc")) {
     getcF->setName("getc_unlocked");
   }

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -34,7 +34,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "getchar", "getchar_unlocked" },   { "putc", "putc_unlocked" },
   { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
   { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
-  { "vfprintf", "vfprintf_unlocked" },
+  { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,13 +27,14 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fgetc", "fgetc_unlocked" },     { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" },     { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" },     { "fprintf", "fprintf_unlocked" },
-  { "fscanf", "fscanf_unlocked" },   { "getc", "getc_unlocked" },
-  { "getchar", "getchar_unlocked" }, { "putc", "putc_unlocked" },
-  { "putchar", "putchar_unlocked" }, { "printf", "printf_unlocked" },
-  { "scanf", "scanf_unlocked" },     { "ungetc", "ungetc_unlocked" },
+  { "fgetc", "fgetc_unlocked" },       { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" },       { "fputs", "fputs_unlocked" },
+  { "fread", "fread_unlocked" },       { "fprintf", "fprintf_unlocked" },
+  { "fscanf", "fscanf_unlocked" },     { "getc", "getc_unlocked" },
+  { "getchar", "getchar_unlocked" },   { "putc", "putc_unlocked" },
+  { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
+  { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
+  { "vfprintf", "vfprintf_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -19,6 +19,7 @@
  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #include "InputOutput.hpp"
 
 #include "noelle/core/Noelle.hpp"
@@ -26,9 +27,8 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fgetc", "fgetc_unlocked" },
-  { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" },
+  { "fgetc", "fgetc_unlocked" }, { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" }, { "fputs", "fputs_unlocked" },
   { "getc", "getc_unlocked" },
 };
 

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -35,6 +35,10 @@ bool InputOutput::runOnModule(Module &M) {
     getcF->setName("fgets_unlocked");
   }
 
+  if (auto getcF = M.getFunction("fputc")) {
+    getcF->setName("fputc_unlocked");
+  }
+
   if (auto getcF = M.getFunction("getc")) {
     getcF->setName("getc_unlocked");
   }

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -26,7 +26,7 @@
 
 namespace llvm::noelle {
 
-std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
+std::unordered_map<std::string, std::string> InputOutput::stdioUnlockedFunctionMapping = {
   { "getc",
     "getc_unlocked" }, // https://pubs.opengroup.org/onlinepubs/9699919799/functions/getc_unlocked.html
   { "getchar",

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -78,9 +78,9 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
 InputOutput::InputOutput() : ModulePass{ ID } {}
 
 bool InputOutput::runOnModule(Module &M) {
-  for (auto [ioWithLock, ioWithoutLock] : stdioUnlockedFunctionMapping) {
-    if (auto getcF = M.getFunction(ioWithLock)) {
-      getcF->setName(ioWithoutLock);
+  for (auto [io, ioUnlocked] : stdioUnlockedFunctionMapping) {
+    if (auto F = M.getFunction(io)) {
+      F->setName(ioUnlocked);
     }
   }
 

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -29,7 +29,8 @@ namespace llvm::noelle {
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "fgetc", "fgetc_unlocked" }, { "fgets", "fgets_unlocked" },
   { "fputc", "fputc_unlocked" }, { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" }, { "getc", "getc_unlocked" },
+  { "fread", "fread_unlocked" }, { "fprintf", "fprintf_unlocked" },
+  { "getc", "getc_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,10 +27,10 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fgetc", "fgetc_unlocked" }, { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" }, { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" }, { "fprintf", "fprintf_unlocked" },
-  { "getc", "getc_unlocked" },
+  { "fgetc", "fgetc_unlocked" },   { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" },   { "fputs", "fputs_unlocked" },
+  { "fread", "fread_unlocked" },   { "fprintf", "fprintf_unlocked" },
+  { "fscanf", "fscanf_unlocked" }, { "getc", "getc_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -33,6 +33,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "fscanf", "fscanf_unlocked" },   { "getc", "getc_unlocked" },
   { "getchar", "getchar_unlocked" }, { "putc", "putc_unlocked" },
   { "putchar", "putchar_unlocked" }, { "printf", "printf_unlocked" },
+  { "scanf", "scanf_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,6 +27,10 @@ namespace llvm::noelle {
 InputOutput::InputOutput() : ModulePass{ ID } {}
 
 bool InputOutput::runOnModule(Module &M) {
+  if (auto getcF = M.getFunction("fgetc")) {
+    getcF->setName("fgetc_unlocked");
+  }
+
   if (auto getcF = M.getFunction("getc")) {
     getcF->setName("getc_unlocked");
   }

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -19,28 +19,26 @@
  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#include "noelle/core/Noelle.hpp"
 #include "InputOutput.hpp"
 
+#include "noelle/core/Noelle.hpp"
+
 namespace llvm::noelle {
+
+std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
+  { "fgetc", "fgetc_unlocked" },
+  { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" },
+  { "getc", "getc_unlocked" },
+};
 
 InputOutput::InputOutput() : ModulePass{ ID } {}
 
 bool InputOutput::runOnModule(Module &M) {
-  if (auto getcF = M.getFunction("fgetc")) {
-    getcF->setName("fgetc_unlocked");
-  }
-
-  if (auto getcF = M.getFunction("fgets")) {
-    getcF->setName("fgets_unlocked");
-  }
-
-  if (auto getcF = M.getFunction("fputc")) {
-    getcF->setName("fputc_unlocked");
-  }
-
-  if (auto getcF = M.getFunction("getc")) {
-    getcF->setName("getc_unlocked");
+  for (auto [ioWithLock, ioWithoutLock] : stdioUnlockedFunctionMapping) {
+    if (auto getcF = M.getFunction(ioWithLock)) {
+      getcF->setName(ioWithoutLock);
+    }
   }
 
   return false;

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -29,7 +29,7 @@ namespace llvm::noelle {
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "fgetc", "fgetc_unlocked" }, { "fgets", "fgets_unlocked" },
   { "fputc", "fputc_unlocked" }, { "fputs", "fputs_unlocked" },
-  { "getc", "getc_unlocked" },
+  { "fread", "fread_unlocked" }, { "getc", "getc_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,7 +27,10 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "clearerr", "clearerr_unlocked" }, { "fclose", "fclose_unlocked" },
+  { "clearerr", "clearerr_unlocked" },
+
+  { "feof", "feof_unlocked" },
+
   { "fflush", "fflush_unlocked" },     { "fgetc", "fgetc_unlocked" },
   { "fgets", "fgets_unlocked" },       { "fputc", "fputc_unlocked" },
   { "fputs", "fputs_unlocked" },       { "fread", "fread_unlocked" },

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -35,7 +35,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
   { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
   { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
-  { "vprintf", "vprintf_unlocked" },
+  { "vprintf", "vprintf_unlocked" },   { "vscanf", "vscanf_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,11 +27,11 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fgetc", "fgetc_unlocked" },    { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" },    { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" },    { "fprintf", "fprintf_unlocked" },
-  { "fscanf", "fscanf_unlocked" },  { "getc", "getc_unlocked" },
-  { "getchar", "getchar_unlocked" }
+  { "fgetc", "fgetc_unlocked" },     { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" },     { "fputs", "fputs_unlocked" },
+  { "fread", "fread_unlocked" },     { "fprintf", "fprintf_unlocked" },
+  { "fscanf", "fscanf_unlocked" },   { "getc", "getc_unlocked" },
+  { "getchar", "getchar_unlocked" }, { "putc", "putc_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -19,10 +19,8 @@
  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
-#include "InputOutput.hpp"
-
 #include "noelle/core/Noelle.hpp"
+#include "InputOutput.hpp"
 
 namespace llvm::noelle {
 

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,10 +27,8 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "clearerr", "clearerr_unlocked" },
-
-  { "feof", "feof_unlocked" },
-
+  { "clearerr", "clearerr_unlocked" }, { "fclose", "fclose_unlocked" },
+  { "feof", "feof_unlocked" },         { "ferror", "ferror_unlocked" },
   { "fflush", "fflush_unlocked" },     { "fgetc", "fgetc_unlocked" },
   { "fgets", "fgets_unlocked" },       { "fputc", "fputc_unlocked" },
   { "fputs", "fputs_unlocked" },       { "fread", "fread_unlocked" },

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -32,6 +32,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "fread", "fread_unlocked" },     { "fprintf", "fprintf_unlocked" },
   { "fscanf", "fscanf_unlocked" },   { "getc", "getc_unlocked" },
   { "getchar", "getchar_unlocked" }, { "putc", "putc_unlocked" },
+  { "putchar", "putchar_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,18 +27,52 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "clearerr", "clearerr_unlocked" }, { "fclose", "fclose_unlocked" },
-  { "feof", "feof_unlocked" },         { "ferror", "ferror_unlocked" },
-  { "fflush", "fflush_unlocked" },     { "fgetc", "fgetc_unlocked" },
-  { "fgets", "fgets_unlocked" },       { "fputc", "fputc_unlocked" },
-  { "fputs", "fputs_unlocked" },       { "fread", "fread_unlocked" },
-  { "fprintf", "fprintf_unlocked" },   { "fscanf", "fscanf_unlocked" },
-  { "getc", "getc_unlocked" },         { "getchar", "getchar_unlocked" },
-  { "putc", "putc_unlocked" },         { "putchar", "putchar_unlocked" },
-  { "printf", "printf_unlocked" },     { "scanf", "scanf_unlocked" },
-  { "ungetc", "ungetc_unlocked" },     { "vfprintf", "vfprintf_unlocked" },
-  { "vfscanf", "vfscanf_unlocked" },   { "vprintf", "vprintf_unlocked" },
-  { "vscanf", "vscanf_unlocked" },     { "fwrite", "fwrite_unlocked" },
+  { "getc",
+    "getc_unlocked" }, // https://pubs.opengroup.org/onlinepubs/9699919799/functions/getc_unlocked.html
+  { "getchar",
+    "getchar_unlocked" }, // https://pubs.opengroup.org/onlinepubs/9699919799/functions/getchar_unlocked.html
+  { "putc",
+    "putc_unlocked" }, // https://pubs.opengroup.org/onlinepubs/9699919799/functions/putc_unlocked.html
+  { "putchar",
+    "putchar_unlocked" }, // https://pubs.opengroup.org/onlinepubs/9699919799/functions/putchar_unlocked.html
+  { "clearerr",
+    "clearerr_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-clearerr-unlocked-1.html
+  { "feof",
+    "feof_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-feof-unlocked-1.html
+  { "ferror",
+    "ferror_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-ferror-unlocked-1.html
+  { "fflush",
+    "fflush_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fflush-unlocked-1.html
+  { "fgetc",
+    "fgetc_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fgetc-unlocked-1.html
+  { "fgets",
+    "fgets_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fgets-unlocked-1.html
+  { "fileno",
+    "fileno_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fileno-unlocked-1.html
+  { "fputc",
+    "fputc_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fputc-unlocked-1.html
+  { "fputs",
+    "fputs_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fputs-unlocked-1.html
+  { "fread",
+    "fread_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fread-unlocked-1.html
+  { "fwrite",
+    "fwrite_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fwrite-unlocked-1.html
+  { "fgetwc",
+    "fgetwc_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fgetwc-unlocked-1.html
+  { "fgetws",
+    "fgetws_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fgetws-unlocked-1.html
+  { "fputwc",
+    "fputwc_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fputwc-unlocked-1.html
+  { "fputws",
+    "fputws_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-fputws-unlocked-1.html
+  { "getwc",
+    "getwc_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-getwc-unlocked-1.html
+  { "getwchar",
+    "getwchar_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-getwchar-unlocked-1.html
+  { "putwc",
+    "putwc_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-putwc-unlocked-1.html
+  { "putwchar",
+    "putwchar_unlocked" }, // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-putwchar-unlocked-1.html
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,16 +27,16 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fgetc", "fgetc_unlocked" },       { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" },       { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" },       { "fprintf", "fprintf_unlocked" },
-  { "fscanf", "fscanf_unlocked" },     { "getc", "getc_unlocked" },
-  { "getchar", "getchar_unlocked" },   { "putc", "putc_unlocked" },
-  { "putchar", "putchar_unlocked" },   { "printf", "printf_unlocked" },
-  { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
-  { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
-  { "vprintf", "vprintf_unlocked" },   { "vscanf", "vscanf_unlocked" },
-  { "fwrite", "fwrite_unlocked" },
+  { "fclose", "fclose_unlocked" },   { "fgetc", "fgetc_unlocked" },
+  { "fgets", "fgets_unlocked" },     { "fputc", "fputc_unlocked" },
+  { "fputs", "fputs_unlocked" },     { "fread", "fread_unlocked" },
+  { "fprintf", "fprintf_unlocked" }, { "fscanf", "fscanf_unlocked" },
+  { "getc", "getc_unlocked" },       { "getchar", "getchar_unlocked" },
+  { "putc", "putc_unlocked" },       { "putchar", "putchar_unlocked" },
+  { "printf", "printf_unlocked" },   { "scanf", "scanf_unlocked" },
+  { "ungetc", "ungetc_unlocked" },   { "vfprintf", "vfprintf_unlocked" },
+  { "vfscanf", "vfscanf_unlocked" }, { "vprintf", "vprintf_unlocked" },
+  { "vscanf", "vscanf_unlocked" },   { "fwrite", "fwrite_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -32,7 +32,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "fread", "fread_unlocked" },     { "fprintf", "fprintf_unlocked" },
   { "fscanf", "fscanf_unlocked" },   { "getc", "getc_unlocked" },
   { "getchar", "getchar_unlocked" }, { "putc", "putc_unlocked" },
-  { "putchar", "putchar_unlocked" },
+  { "putchar", "putchar_unlocked" }, { "printf", "printf_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -33,7 +33,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "fscanf", "fscanf_unlocked" },   { "getc", "getc_unlocked" },
   { "getchar", "getchar_unlocked" }, { "putc", "putc_unlocked" },
   { "putchar", "putchar_unlocked" }, { "printf", "printf_unlocked" },
-  { "scanf", "scanf_unlocked" },
+  { "scanf", "scanf_unlocked" },     { "ungetc", "ungetc_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -36,6 +36,7 @@ std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
   { "scanf", "scanf_unlocked" },       { "ungetc", "ungetc_unlocked" },
   { "vfprintf", "vfprintf_unlocked" }, { "vfscanf", "vfscanf_unlocked" },
   { "vprintf", "vprintf_unlocked" },   { "vscanf", "vscanf_unlocked" },
+  { "fwrite", "fwrite_unlocked" },
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.cpp
+++ b/src/tools/input_output/src/InputOutput.cpp
@@ -27,10 +27,11 @@
 namespace llvm::noelle {
 
 std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping = {
-  { "fgetc", "fgetc_unlocked" },   { "fgets", "fgets_unlocked" },
-  { "fputc", "fputc_unlocked" },   { "fputs", "fputs_unlocked" },
-  { "fread", "fread_unlocked" },   { "fprintf", "fprintf_unlocked" },
-  { "fscanf", "fscanf_unlocked" }, { "getc", "getc_unlocked" },
+  { "fgetc", "fgetc_unlocked" },    { "fgets", "fgets_unlocked" },
+  { "fputc", "fputc_unlocked" },    { "fputs", "fputs_unlocked" },
+  { "fread", "fread_unlocked" },    { "fprintf", "fprintf_unlocked" },
+  { "fscanf", "fscanf_unlocked" },  { "getc", "getc_unlocked" },
+  { "getchar", "getchar_unlocked" }
 };
 
 InputOutput::InputOutput() : ModulePass{ ID } {}

--- a/src/tools/input_output/src/InputOutput.hpp
+++ b/src/tools/input_output/src/InputOutput.hpp
@@ -41,6 +41,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
 private:
+  std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping;
 };
 
 } // namespace llvm::noelle

--- a/src/tools/input_output/src/InputOutput.hpp
+++ b/src/tools/input_output/src/InputOutput.hpp
@@ -41,7 +41,8 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
 private:
-  std::unordered_map<std::string, std::string> stdioUnlockedFunctionMapping;
+  static std::unordered_map<std::string, std::string>
+      stdioUnlockedFunctionMapping;
 };
 
 } // namespace llvm::noelle


### PR DESCRIPTION
- Since we will handle the synchronization manually, using the unlocked version of stdio functions are safe without acquiring and releasing locks for files in runtime.
- References:
	- https://github.com/arcana-lab/noelle/pull/82
	- https://www.gnu.org/software/gnulib/manual/html_node/
- stdio functions that the IO Enabler will handle:
	- `getc`
	- `getcchar`
	- `putc`
	- `putchar`
	- `clearerr`
	- `feof`
	- `ferror`
	- `fflush`
	- `fgetc`
	- `fgets`
	- `fileno`
	- `fputc`
	- `fputs`
	- `fread`
	- `fwrite`
	- `fgetwc`
	- `fgetws`
	- `fputwc`
	- `fputws`
	- `getwc`
	- `getwchar`
	- `putwc`
	- `putwchar`
