### PR TITLE
Parallelizer: fixed missing condition

### DIFF
--- a/src/tools/scripts/noelle-parallelizer-singleloop
+++ b/src/tools/scripts/noelle-parallelizer-singleloop
@@ -26,7 +26,16 @@ showReturnCode() {
   else
     colorRetCode="\033[1;31m$retCode\033[0m"
   fi
-  echo -e "${prefix}     returned code $colorRetCode"
+  description=""
+  case $retCode in
+    124)
+      description="(timed out)"
+      ;;
+    139)
+      description="(seg fault)"
+      ;;
+  esac
+  echo -e "${prefix}     returned code $colorRetCode $description"
 }
 
 #------ Beginning --------------------------------------------------------------#


### PR DESCRIPTION
This PR fixes the policy with which loops with a parallel plan are selected in the `parallelizer` tool.

Also, `noelle-parallelizer-singleloop` now has a brief description of the error code (timed out | seg fault)