### PR TITLE
Noelle: fix issue of DoallLastIteration testcase

### DIFF
--- a/tests/regression/DoallLastIteration/test.cpp
+++ b/tests/regression/DoallLastIteration/test.cpp
@@ -3,9 +3,9 @@
 #include <iostream>
 
 int main(int argc, char *argv[]) {
-  int *p = (int *)malloc(100 * sizeof(int));
-  int *q = (int *)malloc(100 * sizeof(int));
-  int *r = (int *)malloc(100 * sizeof(int));
+  int *p = (int *)malloc(101 * sizeof(int));
+  int *q = (int *)malloc(101 * sizeof(int));
+  int *r = (int *)malloc(101 * sizeof(int));
 
   int *old_p = p;
   for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Pointers p, q, r access the 100th element, which is not part of the allocated memory objects.