### PR TITLE
Update may_points_to_analysis and pdg_analysis

### DIFF
--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -1,4 +1,4 @@
-UTILS=transformations basic_utilities types_manager globals_manager functions_manager constants_manager compilation_options_manager linker dominators task loop_induction_variables loop_carried_dependences memory_cloning_analysis loop_scc_attributes loop_sccdag_attributes loop_sccdag_normalizer loop_dependence_analyses loop_content loop_nesting_graph architecture metadata_cleaner callgraph scheduler metadata_manager loop_transformer alias_analysis_engine codesize
+UTILS=transformations basic_utilities types_manager globals_manager functions_manager constants_manager compilation_options_manager linker dominators task loop_induction_variables loop_carried_dependences may_points_to_analysis memory_cloning_analysis loop_scc_attributes loop_sccdag_attributes loop_sccdag_normalizer loop_dependence_analyses loop_content loop_nesting_graph architecture metadata_cleaner callgraph scheduler metadata_manager loop_transformer alias_analysis_engine codesize
 ANALYSIS=dg pdg sccdag pdg_printer pdg_analysis talkdown alloc_aa dataflow loop_structure loop_environment loop_forest loop_invariants
 ENABLERS=loop_distribution loop_unroll loop_whilifier outliner cfg_analysis cfg_transformer
 ALL=$(UTILS) $(ANALYSIS) $(ENABLERS) loop_metadata hotprofiler unique_ir_marker noelle scripts
@@ -87,6 +87,9 @@ loop_induction_variables:
 	cd $@ ; ../../scripts/run_me.sh
 
 loop_carried_dependences:
+	cd $@ ; ../../scripts/run_me.sh
+
+may_points_to_analysis:
 	cd $@ ; ../../scripts/run_me.sh
 
 memory_cloning_analysis:

--- a/src/core/functions_manager/src/CMakeLists.txt
+++ b/src/core/functions_manager/src/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(${LLVM_INCLUDE_DIRS}
   ../../loop_structure/include
   ../../dataflow/include
   ../../types_manager/include
+  ../../may_points_to_analysis/include
   ${CMAKE_INSTALL_PREFIX}/include
   )
 

--- a/src/core/loop_content/src/CMakeLists.txt
+++ b/src/core/loop_content/src/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(${LLVM_INCLUDE_DIRS}
   ../../alias_analysis_engine/include
   ../../loop_dependence_analyses/include
   ../../compilation_options_manager/include
+  ../../may_points_to_analysis/include
   ../include
   ./
   ${CMAKE_INSTALL_PREFIX}/include

--- a/src/core/loop_dependence_analyses/src/CMakeLists.txt
+++ b/src/core/loop_dependence_analyses/src/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories(${LLVM_INCLUDE_DIRS}
   ../../loop_scc_attributes/include
   ../../loop_sccdag_attributes/include
   ../../loop_carried_dependences/include
+  ../../may_points_to_analysis/include
   ../include
   ./
   ${CMAKE_INSTALL_PREFIX}/include

--- a/src/core/loop_sccdag_normalizer/src/CMakeLists.txt
+++ b/src/core/loop_sccdag_normalizer/src/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(${LLVM_INCLUDE_DIRS}
   ../../alias_analysis_engine/include
   ../../loop_dependence_analyses/include
   ../../compilation_options_manager/include
+  ../../may_points_to_analysis/include
   ../include
   ./
   ${CMAKE_INSTALL_PREFIX}/include

--- a/src/core/may_points_to_analysis/CMakeLists.txt
+++ b/src/core/may_points_to_analysis/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Project
+cmake_minimum_required(VERSION 3.13)
+project(MayPointsToAnalysis)
+
+# Dependences
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/DependencesCMake.txt)
+
+# Pass
+add_subdirectory(src)
+
+# Install
+install(
+  FILES
+  include/noelle/core/MayPointsToAnalysis.hpp
+  DESTINATION 
+  include/noelle/core
+  )

--- a/src/core/may_points_to_analysis/include/noelle/core/MayPointsToAnalysis.hpp
+++ b/src/core/may_points_to_analysis/include/noelle/core/MayPointsToAnalysis.hpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2023 Xiao Chen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "noelle/core/Utils.hpp"
+
+namespace llvm::noelle {
+
+typedef uint64_t NodeID;
+
+class MpaSummary {
+public:
+  MpaSummary(Function *currentF);
+
+  Function *currentF;
+
+  std::unordered_set<StoreInst *> storeInsts;
+  std::unordered_set<AllocaInst *> allocaInsts;
+  std::unordered_set<CallBase *> mallocInsts;
+  std::unordered_set<CallBase *> callocInsts;
+  std::unordered_set<CallBase *> freeInsts;
+
+  bool mayBePointedByUnknown(Value *ptr);
+  std::unordered_set<Value *> getPointees(Value *ptr);
+
+private:
+  /*
+   * All pointers may be used as return value of current function.
+   */
+  std::unordered_set<Value *> returnPointers;
+  /*
+   * All pointers in current function.
+   */
+  std::unordered_set<Value *> pointers;
+
+  bool mpaFinished = false;
+  const NodeID UnknownMemobjId = 0;
+  NodeID nextNodeId = 1;
+
+  /*
+   * Assign node id to each pointer in current function.
+   */
+  std::unordered_map<Value *, NodeID> ptr2nodeId;
+
+  /*
+   * Assign node id to each memory object, the memory object is represented
+   * by the souce of allocation.
+   *
+   * 1. The allocation source can be a AllocaInst, a malloc/calloc call,
+   *    or allocaCandidate.
+   * 2. Besides, we have a "unknown" memobj, which always has node id 0 and
+   *    its allocation souce is nullptr, which is a summary of all memobjs not
+   *    allocated by current function.
+   *
+   * Arguments of current function and global variables point to "unknown"
+   * memobj. Pointers returned by callInsts point to "unknown" memobj. "unkonwn"
+   * memobj points to itself since it's a summary.
+   */
+  std::unordered_map<Value *, NodeID> memobj2nodeId;
+  std::unordered_map<NodeID, Value *> nodeId2memobj;
+
+  /*
+   * The memory objects pointed by pointers and memory objects.
+   */
+  std::unordered_map<NodeID, BitVector> pointsTo;
+
+  /*
+   * A copy edge (src => dest) means that dest may point to the same memobjs
+   * as src. To be more specific, pts(dest) = pts(dest) U pts(src).
+   * Here both src and dest can be pointers or memobjs.
+   *
+   * For example. if we have %1 = select i1 %cond, i32* %ptr1, i32* %ptr2,
+   * then we add two copy edges: "%ptr1 => %1" and "%ptr2 => %1",
+   * and we have pts(%1) = pts(%ptr1) U pts(%ptr2).
+   */
+  std::unordered_map<NodeID, std::unordered_set<NodeID>> copyOutEdges;
+
+  /*
+   * storeInst = `store i32* %p1, i32** %p2` is an incomingStore of %p2
+   * since %p2 is used as the pointer operand of storeInst, and the points-to
+   * info flows from %p1 into the memory objects pointed by %p2.
+   */
+  std::unordered_map<NodeID, std::unordered_set<StoreInst *>> incomingStores;
+
+  /*
+   * `%3 = load i32*, i32** %p2` is an outgoingLoad of %p2 since %p2 is used
+   * as the pointer operand of loadInst, the points-to info flows out of the
+   * memobjs pointed by %2 to the loadInst.
+   */
+  std::unordered_map<NodeID, std::unordered_set<LoadInst *>> outgoingLoads;
+
+  /*
+   * All pointers used as arguments of callInsts in current function.
+   */
+  std::unordered_set<NodeID> usedAsFuncArg;
+
+  /*
+   * allocaCandidate is a global variable that we want to privatize into
+   * current function, i.e. it works like an allocaInst in current function.
+   *
+   * Usually, global variables point to "unknown" memobj, but allocaCandidate
+   * is an exception. We assign a node id for the memobj of allocaCandidate,
+   * which is different from all other memobjs from alloca/malloc/calloc and
+   * "unkonwn" memobj.
+   *
+   * The reason to introduce allocaCandidate is to check the memory object of
+   * the global variable will not be pointed by other global variables,
+   * arguments of the current function, and the return values of the current
+   * function. i.e. allocaCandidate and notPrivatizable() help check the third
+   * condition from Privatizer::getPrivatizableFunctions().
+   */
+  GlobalVariable *allocaCandidate = nullptr;
+
+  std::queue<NodeID> worklist;
+
+  BitVector getEmptyBitVector(void);
+  BitVector onlyPointsTo(NodeID memobjId);
+  std::unordered_set<Value *> getAllocations(void);
+  NodeID getPtrId(Value *v);
+  bool addCopyEdge(NodeID src, NodeID dst);
+
+  void mayPointsToAnalysis(void);
+  void initPtInfo(void);
+  void solveWorklist(void);
+
+  void handleLoadStore(NodeID ptrId);
+  void handleFuncUsers(NodeID ptrId);
+  void handleCopyEdges(NodeID srcId);
+
+  BitVector getPointees(NodeID nodeId);
+  std::unordered_set<NodeID> getReachableMemobjs(NodeID ptrId);
+  bool unionPts(NodeID srcId, NodeID dstId);
+};
+
+class MayPointsToAnalysis {
+public:
+  MayPointsToAnalysis();
+
+  bool mayAlias(Value *ptr1, Value *ptr2);
+  bool mayEscape(Instruction *inst);
+  bool notPrivatizable(GlobalVariable *globalVar, Function *currentF);
+
+  ~MayPointsToAnalysis();
+
+private:
+  std::unordered_map<Function *, MpaSummary *> functionSummaries;
+
+  MpaSummary *getFunctionSummary(Function *currentF);
+};
+
+} // namespace llvm::noelle

--- a/src/core/may_points_to_analysis/include/noelle/core/MayPointsToAnalysis.hpp
+++ b/src/core/may_points_to_analysis/include/noelle/core/MayPointsToAnalysis.hpp
@@ -42,7 +42,6 @@ public:
   bool mayBePointedByUnknown(Value *memobj);
   bool mayBePointedByReturnValue(Value *memobj);
   std::unordered_set<Value *> getPointeeMemobjs(Value *ptr);
-  std::unordered_set<Value *> getReachableMemobjs(Value *ptr);
 
   void doMayPointsToAnalysis(void);
   void doMayPointsToAnalysisFor(GlobalVariable *globalVar);
@@ -196,7 +195,6 @@ public:
   bool mayAlias(Value *ptr1, Value *ptr2);
   bool mayEscape(Instruction *inst);
   bool notPrivatizable(GlobalVariable *globalVar, Function *currentF);
-  bool mayAccessEscapedMemobj(Instruction *inst);
   std::unordered_set<Value *> getPointees(Value *ptr, Function *currentF);
 
   ~MayPointsToAnalysis();

--- a/src/core/may_points_to_analysis/src/CMakeLists.txt
+++ b/src/core/may_points_to_analysis/src/CMakeLists.txt
@@ -25,13 +25,8 @@ message(STATUS "LLVM_DIR IS ${LLVM_CMAKE_DIR}.")
 
 include_directories(${LLVM_INCLUDE_DIRS} 
   ../../basic_utilities/include
-  ../../loop_forest/include
-  ../../loop_structure/include 
-  ../../dominators/include 
-  ../../callgraph/include
   ../include
   ./
-  ${CMAKE_INSTALL_PREFIX}/include
   )
 
 # Declare the LLVM pass to compile

--- a/src/core/may_points_to_analysis/src/CMakeLists.txt
+++ b/src/core/may_points_to_analysis/src/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Sources
+set(Srcs
+  MayPointsToAnalysis.cpp
+  MpaSummary.cpp
+  MpaUtils.cpp
+)
+
+# Compilation flags
+set_source_files_properties(${Srcs} PROPERTIES COMPILE_FLAGS " -std=c++17 -fPIC")
+
+# Name of the LLVM pass
+set(PassName "MayPointsToAnalysis")
+
+# configure LLVM 
+find_package(LLVM 9 REQUIRED CONFIG)
+
+set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/)
+
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(HandleLLVMOptions)
+include(AddLLVM)
+
+message(STATUS "LLVM_DIR IS ${LLVM_CMAKE_DIR}.")
+
+include_directories(${LLVM_INCLUDE_DIRS} 
+  ../../basic_utilities/include
+  ../../loop_forest/include
+  ../../loop_structure/include 
+  ../../dominators/include 
+  ../../callgraph/include
+  ../include
+  ./
+  ${CMAKE_INSTALL_PREFIX}/include
+  )
+
+# Declare the LLVM pass to compile
+add_llvm_library(${PassName} MODULE ${Srcs})

--- a/src/core/may_points_to_analysis/src/MayPointsToAnalysis.cpp
+++ b/src/core/may_points_to_analysis/src/MayPointsToAnalysis.cpp
@@ -98,32 +98,6 @@ bool MayPointsToAnalysis::notPrivatizable(GlobalVariable *globalVar,
   return result;
 }
 
-bool MayPointsToAnalysis::mayAccessEscapedMemobj(Instruction *inst) {
-  if (!isa<LoadInst>(inst) && !isa<StoreInst>(inst)) {
-    return true;
-  }
-
-  auto currentF = inst->getFunction();
-  auto funcSum = getFunctionSummary(currentF);
-
-  Value *ptr;
-  if (isa<LoadInst>(inst)) {
-    ptr = dyn_cast<LoadInst>(inst)->getPointerOperand();
-  } else if (isa<StoreInst>(inst)) {
-    ptr = dyn_cast<StoreInst>(inst)->getPointerOperand();
-  }
-
-  funcSum->doMayPointsToAnalysis();
-  auto pointees = funcSum->getReachableMemobjs(ptr);
-  for (auto memobj : pointees) {
-    if (memobj == nullptr || funcSum->mayBePointedByUnknown(memobj)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 std::unordered_set<Value *> MayPointsToAnalysis::getPointees(
     Value *ptr,
     Function *currentF) {

--- a/src/core/may_points_to_analysis/src/MayPointsToAnalysis.cpp
+++ b/src/core/may_points_to_analysis/src/MayPointsToAnalysis.cpp
@@ -42,6 +42,10 @@ bool MayPointsToAnalysis::mayAlias(Value *ptr1, Value *ptr2) {
   auto stripped1 = strip(ptr1);
   auto stripped2 = strip(ptr2);
 
+  if (stripped1 == stripped2) {
+    return true;
+  }
+
   auto func1 = getOwnerFunction(stripped1);
   auto func2 = getOwnerFunction(stripped2);
 

--- a/src/core/may_points_to_analysis/src/MayPointsToAnalysis.cpp
+++ b/src/core/may_points_to_analysis/src/MayPointsToAnalysis.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Xiao Chen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "noelle/core/MayPointsToAnalysis.hpp"
+#include "MpaUtils.hpp"
+
+namespace llvm::noelle {
+
+MayPointsToAnalysis::MayPointsToAnalysis() {}
+
+bool MayPointsToAnalysis::mayAlias(Value *ptr1, Value *ptr2) {
+  assert(ptr1->getType()->isPointerTy() && ptr2->getType()->isPointerTy());
+
+  auto getOwnerFunction = [](Value *ptr) -> Function * {
+    auto stripped = strip(ptr);
+    if (isa<Instruction>(stripped)) {
+      return dyn_cast<Instruction>(stripped)->getFunction();
+    } else if (isa<Argument>(stripped)) {
+      return dyn_cast<Argument>(stripped)->getParent();
+    } else {
+      return nullptr;
+    }
+  };
+
+  auto func1 = getOwnerFunction(ptr1);
+  auto func2 = getOwnerFunction(ptr2);
+
+  if (func1 == nullptr && func2 == nullptr) {
+    if (isa<GlobalVariable>(ptr1) && isa<GlobalVariable>(ptr2)
+        && (ptr1 != ptr2)) {
+      return false;
+    } else {
+      return true;
+    }
+  } else if (func1 != nullptr && func2 == nullptr) {
+    auto funcSum = getFunctionSummary(func1);
+    return funcSum->getPointees(ptr1).count(nullptr) > 0;
+  } else if (func1 == nullptr && func2 != nullptr) {
+    auto funcSum = getFunctionSummary(func2);
+    return funcSum->getPointees(ptr2).count(nullptr) > 0;
+  } else if (func1 == func2) {
+    auto funcSum = getFunctionSummary(func1);
+    auto ptes1 = funcSum->getPointees(ptr1);
+    auto ptes2 = funcSum->getPointees(ptr2);
+    ptes1.erase(ptes2.begin(), ptes2.end());
+    return !ptes1.empty();
+  } else {
+    auto funcSum1 = getFunctionSummary(func1);
+    auto funcSum2 = getFunctionSummary(func2);
+    return funcSum1->getPointees(ptr1).count(nullptr) > 0
+           || funcSum2->getPointees(ptr2).count(nullptr) > 0;
+  }
+}
+
+bool MayPointsToAnalysis::mayEscape(Instruction *inst) {
+  auto currentF = inst->getFunction();
+  auto funcSum = getFunctionSummary(currentF);
+  return funcSum->mayBePointedByUnknown(inst);
+}
+
+bool MayPointsToAnalysis::notPrivatizable(GlobalVariable *globalVar,
+                                          Function *currentF) {
+  auto funcSum = getFunctionSummary(currentF);
+  return funcSum->mayBePointedByUnknown(globalVar);
+}
+
+MayPointsToAnalysis::~MayPointsToAnalysis() {
+  for (auto &[f, funcSum] : functionSummaries) {
+    delete funcSum;
+  }
+  functionSummaries.clear();
+}
+
+MpaSummary *MayPointsToAnalysis::getFunctionSummary(Function *currentF) {
+  if (functionSummaries.find(currentF) == functionSummaries.end()) {
+    functionSummaries[currentF] = new MpaSummary(currentF);
+  }
+  return functionSummaries[currentF];
+}
+
+} // namespace llvm::noelle

--- a/src/core/may_points_to_analysis/src/MpaSummary.cpp
+++ b/src/core/may_points_to_analysis/src/MpaSummary.cpp
@@ -30,10 +30,23 @@ MpaSummary::MpaSummary(Function *currentF) : currentF(currentF) {
 
   auto insertPointer = [&](Value *v) {
     if (v->getType()->isPointerTy()) {
-      pointers.insert(v);
-      auto stripped = strip(v);
-      if (stripped != v) {
-        pointers.insert(stripped);
+      queue<Value *> todolist;
+      todolist.push(v);
+
+      while (!todolist.empty()) {
+        auto ptr = todolist.front();
+        todolist.pop();
+        pointers.insert(ptr);
+
+        if (isa<GetElementPtrInst>(ptr)) {
+          auto gepInst = dyn_cast<GetElementPtrInst>(ptr);
+          todolist.push(gepInst->getPointerOperand());
+        } else if (isa<GEPOperator>(ptr)) {
+          auto gepOp = dyn_cast<GEPOperator>(ptr);
+          todolist.push(gepOp->getPointerOperand());
+        } else if (isa<BitCastInst>(ptr) || isa<BitCastOperator>(ptr)) {
+          todolist.push(ptr->stripPointerCasts());
+        }
       }
     }
   };
@@ -50,22 +63,22 @@ MpaSummary::MpaSummary(Function *currentF) : currentF(currentF) {
 
   for (auto &bb : *currentF) {
     for (auto &inst : bb) {
-      if (isa<LoadInst>(inst)) {
+      if (isa<LoadInst>(&inst)) {
         auto loadInst = dyn_cast<LoadInst>(&inst);
         insertPointer(loadInst->getPointerOperand());
         insertPointer(loadInst);
-      } else if (isa<StoreInst>(inst)) {
+      } else if (isa<StoreInst>(&inst)) {
         auto storeInst = dyn_cast<StoreInst>(&inst);
         storeInsts.insert(storeInst);
         insertPointer(storeInst->getValueOperand());
         insertPointer(storeInst->getPointerOperand());
-      } else if (isa<BitCastInst>(inst) || isa<GetElementPtrInst>(inst)) {
+      } else if (isa<BitCastInst>(&inst) || isa<GetElementPtrInst>(&inst)) {
         insertPointer(&inst);
-      } else if (isa<AllocaInst>(inst)) {
+      } else if (isa<AllocaInst>(&inst)) {
         auto allocaInst = dyn_cast<AllocaInst>(&inst);
         allocaInsts.insert(allocaInst);
         insertPointer(allocaInst);
-      } else if (isa<CallBase>(inst)) {
+      } else if (isa<CallBase>(&inst)) {
         auto callInst = dyn_cast<CallBase>(&inst);
         auto calleeType = getCalleeFunctionType(callInst);
         switch (calleeType) {
@@ -91,7 +104,18 @@ MpaSummary::MpaSummary(Function *currentF) : currentF(currentF) {
             }
             break;
         }
-      } else if (isa<ReturnInst>(inst)) {
+      } else if (isa<PHINode>(&inst) && inst.getType()->isPointerTy()) {
+        auto phiNode = dyn_cast<PHINode>(&inst);
+        insertPointer(phiNode);
+        for (auto &incoming : phiNode->incoming_values()) {
+          insertPointer(incoming);
+        }
+      } else if (isa<SelectInst>(&inst) && inst.getType()->isPointerTy()) {
+        auto selectInst = dyn_cast<SelectInst>(&inst);
+        insertPointer(selectInst);
+        insertPointer(selectInst->getTrueValue());
+        insertPointer(selectInst->getFalseValue());
+      } else if (isa<ReturnInst>(&inst)) {
         auto returnInst = dyn_cast<ReturnInst>(&inst);
         auto retVal = returnInst->getReturnValue();
         if (retVal && retVal->getType()->isPointerTy()) {
@@ -102,59 +126,70 @@ MpaSummary::MpaSummary(Function *currentF) : currentF(currentF) {
   }
 }
 
-unordered_set<Value *> MpaSummary::getPointees(Value *ptr) {
+unordered_set<Value *> MpaSummary::getPointeeMemobjs(Value *ptr) {
   assert(mpaFinished);
-  assert(ptr2nodeId.find(ptr) != ptr2nodeId.end());
-  auto ptrId = ptr2nodeId[ptr];
+
+  auto stripped = strip(ptr);
+  assert(ptr2nodeId.find(stripped) != ptr2nodeId.end());
+
+  auto ptrId = ptr2nodeId[stripped];
   unordered_set<Value *> pointees;
-  for (auto memobjId : getPointees(ptrId).set_bits()) {
+
+  auto pointeeBitVec = getPointeeBitVector(ptrId);
+  for (auto memobjId : pointeeBitVec.set_bits()) {
     if (memobjId == UnknownMemobjId) {
       pointees.insert(nullptr);
     } else {
-      pointees.insert(nodeId2memobj.at(memobjId));
+      pointees.insert(nodeId2memobj[memobjId]);
     }
   }
   return pointees;
 }
 
-bool MpaSummary::mayBePointedByUnknown(Value *ptr) {
+unordered_set<Value *> MpaSummary::getReachableMemobjs(Value *ptr) {
   assert(mpaFinished);
 
-  auto pointedByUnknown = [this](NodeID nodeId) -> bool {
-    auto unknownPts = this->getReachableMemobjs(this->UnknownMemobjId);
-    if (unknownPts.find(nodeId) != unknownPts.end()) {
-      return true;
-    }
-    for (auto retPtr : this->returnPointers) {
-      auto retPtrId = getPtrId(retPtr);
-      auto retMemobjs = getReachableMemobjs(retPtrId);
-      if (retMemobjs.find(nodeId) != retMemobjs.end()) {
-        return true;
-      }
-    }
-    return false;
-  };
+  auto stripped = strip(ptr);
+  assert(ptr2nodeId.find(stripped) != ptr2nodeId.end());
 
-  if (ptr && isa<GlobalVariable>(ptr)) {
-    auto globalVar = dyn_cast<GlobalVariable>(ptr);
-    allocaCandidate = globalVar;
-    mayPointsToAnalysis();
-    auto memObjId = memobj2nodeId[globalVar];
-    return pointedByUnknown(memObjId);
-  } else if (ptr && getAllocations().count(ptr) > 0) {
-    if (!mpaFinished) {
-      allocaCandidate = nullptr;
-      mayPointsToAnalysis();
-    }
-    auto inst = dyn_cast<Instruction>(ptr);
-    auto memObjId = memobj2nodeId[inst];
-    return pointedByUnknown(memObjId);
-  } else {
-    assert(false && "Not a valid allocation of memory object.");
+  auto ptrId = ptr2nodeId[stripped];
+  unordered_set<Value *> reachable;
+
+  auto reachableMemobjIds = getreachableMemobjIds(ptrId);
+  for (auto memobjId : reachableMemobjIds) {
+    reachable.insert(nodeId2memobj[memobjId]);
   }
+  return reachable;
 }
 
-BitVector MpaSummary::getPointees(NodeID nodeId) {
+bool MpaSummary::mayBePointedByUnknown(Value *memobj) {
+  assert(mpaFinished);
+  assert(getAllocations().count(memobj) > 0);
+  auto memobjId = memobj2nodeId.at(memobj);
+
+  auto unknownPts = getreachableMemobjIds(UnknownMemobjId);
+  if (unknownPts.find(memobjId) != unknownPts.end()) {
+    return true;
+  }
+  return false;
+}
+
+bool MpaSummary::mayBePointedByReturnValue(Value *memobj) {
+  assert(mpaFinished);
+  assert(getAllocations().count(memobj) > 0);
+  auto memobjId = memobj2nodeId.at(memobj);
+
+  for (auto retPtr : returnPointers) {
+    auto retPtrId = getPtrId(retPtr);
+    auto retMemobjs = getreachableMemobjIds(retPtrId);
+    if (retMemobjs.find(memobjId) != retMemobjs.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+BitVector MpaSummary::getPointeeBitVector(NodeID nodeId) {
   if (pointsTo.find(nodeId) != pointsTo.end()) {
     return pointsTo[nodeId];
   } else {
@@ -162,15 +197,17 @@ BitVector MpaSummary::getPointees(NodeID nodeId) {
   }
 }
 
-unordered_set<NodeID> MpaSummary::getReachableMemobjs(NodeID ptrId) {
+unordered_set<NodeID> MpaSummary::getreachableMemobjIds(NodeID ptrId) {
   unordered_set<NodeID> reachable;
   queue<NodeID> todolist;
   todolist.push(ptrId);
+
   while (!todolist.empty()) {
     auto nodeId = todolist.front();
     todolist.pop();
 
-    for (auto memObj : getPointees(nodeId).set_bits()) {
+    auto pointeeBitVec = getPointeeBitVector(nodeId);
+    for (auto memObj : pointeeBitVec.set_bits()) {
       if (reachable.find(memObj) == reachable.end()) {
         reachable.insert(memObj);
         todolist.push(memObj);
@@ -203,14 +240,15 @@ unordered_set<Value *> MpaSummary::getAllocations(void) {
   for (auto &callocInst : callocInsts) {
     allocations.insert(callocInst);
   }
-  if (allocaCandidate) {
-    allocations.insert(allocaCandidate);
+  if (privatizeCandidate) {
+    allocations.insert(privatizeCandidate);
   }
   return allocations;
 }
 
 NodeID MpaSummary::getPtrId(Value *v) {
   assert(v->getType()->isPointerTy());
+
   auto stripped = strip(v);
   if (ptr2nodeId.find(stripped) == ptr2nodeId.end()) {
     ptr2nodeId[stripped] = nextNodeId++;
@@ -222,14 +260,22 @@ bool MpaSummary::addCopyEdge(NodeID src, NodeID dst) {
   return copyOutEdges[src].insert(dst).second;
 }
 
-void MpaSummary::mayPointsToAnalysis(void) {
-  initPtInfo();
-  solveWorklist();
-  mpaFinished = true;
+void MpaSummary::doMayPointsToAnalysis(void) {
+  if (!mpaFinished) {
+    initPtInfo();
+    solveWorklist();
+    mpaFinished = true;
+  }
 }
 
-void MpaSummary::initPtInfo(void) {
+void MpaSummary::doMayPointsToAnalysisFor(GlobalVariable *globalVar) {
+  clearPointsToSummary();
+  privatizeCandidate = globalVar;
+  doMayPointsToAnalysis();
+}
 
+void MpaSummary::clearPointsToSummary(void) {
+  privatizeCandidate = nullptr;
   mpaFinished = false;
   nextNodeId = 1;
   ptr2nodeId.clear();
@@ -240,43 +286,55 @@ void MpaSummary::initPtInfo(void) {
   incomingStores.clear();
   outgoingLoads.clear();
   usedAsFuncArg.clear();
+}
+
+void MpaSummary::initPtInfo(void) {
 
   auto allocations = getAllocations();
 
   /*
-   * Assign node ids to memory objects
-   * 1. Unknown memobj refers to all memobjs allocated in other functions
-   *    and memobjs of global variables. It's nodeId is always 0.
-   * 2. For each memobj allocated by alloca/malloc/calloc, assign a unique
-   *    nodeId.
-   * 3. If a global variable is allocaCandidate, its memobj is not unknown,
-   *    it will be assigned a unique nodeId.
+   * Assign NodeIDs to memory objects
+   * 1. The "unknown" memory object always had NodeID = 0 (see
+   * MayPointsToAnalysis.hpp).
+   * 2. For each memory object allocated by alloca/malloc/calloc, assign a
+   * unique NodeID.
+   * 3. If a global variable is privatizeCandidate, its memory objecg will also
+   * be assigned a unique NodeID.
    */
   nodeId2memobj[UnknownMemobjId] = nullptr;
   memobj2nodeId[nullptr] = UnknownMemobjId;
 
-  for (auto &ptr : allocations) {
+  for (auto &memobj : allocations) {
     auto nodeId = nextNodeId++;
-    nodeId2memobj[nodeId] = ptr;
-    memobj2nodeId[ptr] = nodeId;
+    nodeId2memobj[nodeId] = memobj;
+    memobj2nodeId[memobj] = nodeId;
   }
 
   /*
-   * 1. Assign nodeId to each pointer.
-   * NOTE: The nodeId for the pointer is different from the nodeId for the
-   * memobj. For example, if we have %1 = alloca i32, the nodeId for the
-   * allocated memobj may be 1, the nodeId for the pointer %1 may be 4.
+   * 1. Assign NodeID to each pointer.
+   * NOTE: The NodeID for the pointer is different from the NodeID for the
+   * memobj. For example, if we have `%1 = alloca i32`, the NodeID for the
+   * allocated memory object may be 1, the NodeID for the pointer %1 may be 4.
    *
-   * 2. Initialize points-to information
-   * The unknown memobj conservatively points to itself since it's a summary.
-   * Pointers of alloca/malloc/calloc point to the allocated memobj. Arguments
-   * of current function, global variables and returned pointers of callInsts
-   * will point to unknown memobj (allocaCandidate is the only exception).
+   * 2. Initialize points-to graph.
+   * (1) The "unknown" memory object conservatively points to itself since it's
+   *     a summary.
+   * (2) Pointers of alloca/malloc/calloc point to the allocated memobj.
+   * (3) Arguments of the current function will point to the "unknown" memory
+   *     object, because arguments will points to memory objects not allocated
+   *     in the current function.
+   * (4) Similarly, global variables and the callInsts will also point to the
+   *     "unknown" memory object.
+   * (5) PrivatizeCandidate will points to its own memory object instead of the
+   *     "unknown" memory object (see MayPointsToAnalysis.hpp).
    *
-   * 3. Add copy edges for pointers.
-   * Copy edges between pointers can be added through PHINode, SelectInst,
-   * MemcpyInst and realloc(). "unknown" memobj can be have copy edges from
-   * arguments of callInsts, and copy edges to returned pointers of callInsts.
+   * 3. Add copy edges for pointers and memory objects.
+   * (1) Copy edges between pointers can be added through PHINode, SelectInst,
+   *     MemcpyInst and realloc().
+   * (2) Add copy edges from arguments of callInsts to the "unknown" memory
+   * object because the "unknown" memory object may point to escaped memory
+   * objects. (3) Add copy edges from the "unknown" memory object to the
+   * callInst if the callInst returns a pointer.
    *
    * 4. Record uses of pointers.
    * If a pointer is used as the pointer operand of a store/load instruction,
@@ -374,7 +432,7 @@ void MpaSummary::solveWorklist(void) {
 }
 
 void MpaSummary::handleLoadStore(NodeID ptrId) {
-  auto pointees = getPointees(ptrId);
+  auto pointees = getPointeeBitVector(ptrId);
   for (auto memobjId : pointees.set_bits()) {
     /*
      * OutgoingLoads help us add new copy edges.
@@ -427,34 +485,47 @@ void MpaSummary::handleFuncUsers(NodeID ptrId) {
     return;
   }
   /*
-   * If a pointer is used as argument of a callInst, then all memobjds
-   * reachable from this pointer escape. To preserve conservativeness,
-   * "unknown" memobj and all escaped memobj point to each other.
+   * If a pointer is used as argument of a callInst, then all memory objects
+   * pointed directly or indirectly by this pointer escape. To preserve
+   * conservativeness, the "unknown" memory object and all escaped memory
+   * objects point to each other.
    *
-   * 1. Add copy edge between "unknown" memobj and all escaped memobjds.
+   *
+   * (1) Add copy edges between the "unknown" memory object and all escaped
+   * memory objects.
+   *
    * If memobj @M2 escaped and its points-to info updated:
-   *    pts(@M2) = ... U { @M1 },
+   *     pts(@M2) = ... U { @M1 },
    * such an update should be propagated because @M1 escaped too:
-   *    pts("unknown") = ... U { @M1 }.
+   *     pts("unknown") = ... U { @M1 }.
    *
-   * 2. Add copy edge from the pointer argument to "unknown" memobj.
-   * Assume pointer %p1 is used as argument of a callInst `call @g(%p1)`,
-   * and we have this points-to graph:
-   *    %p1 -> @M1, @M2 ; @M1 -> @M3, @M4
-   * Adding copy edges between "unknown" memobj and { @M1, @M2, @M3, @M4 }
-   * is not enough because @M1 and @M2 are not pointed by any escaped memobj.
-   * Hence "unknown" memobj will not point to @M1 and @M2. To solve this issue,
-   * we need also to add copy edges from  %p1 to "unknown" memobj so that
-   * "unkonwn" can point to @M1 and @M2.
    *
-   * 3. Add copy edge from "unknown" memobj to the return value.
+   * (2) Add copy edge from the pointer argument to the "unknown" memory object.
+   *
+   * Assume pointer %p1 is used as argument of a callInst `call @g(%p1)`, and we
+   * have this points-to graph:
+   *
+   *     %p1 -> @M1, @M2 ; @M1 -> @M3, @M4
+   *
+   * Adding copy edges between the "unknown" memory object and { @M1, @M2, @M3,
+   * @M4 } is not enough because @M1 and @M2 are not pointed by any escaped
+   * memory object. Hence the "unknown" memory object will not point to @M1 and
+   * @M2.
+   *
+   * To solve this issue, we need also to add copy edges from %p1 to the
+   * "unknown" memory object so that "unkonwn" can point to @M1 and @M2.
+   *
+   *
+   * (3) Add copy edge from the "unknown" memory object to the return value.
+   *
    * If the return value of the callInst is a pointer, it will conservatively
-   * point to "unknown" memobj and all escaped memobj.
+   * point to the "unknown" memory object and all escaped memory object.
+   *
    *
    * Here we only handle case 1. Case 2 and 3 are already handled by
    * initPtInfo().
    */
-  for (auto memobjId : getReachableMemobjs(ptrId)) {
+  for (auto memobjId : getreachableMemobjIds(ptrId)) {
     bool changed = false;
     changed |= addCopyEdge(memobjId, UnknownMemobjId);
     changed |= addCopyEdge(UnknownMemobjId, memobjId);

--- a/src/core/may_points_to_analysis/src/MpaSummary.cpp
+++ b/src/core/may_points_to_analysis/src/MpaSummary.cpp
@@ -1,0 +1,494 @@
+/*
+ * Copyright 2023 Xiao Chen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "noelle/core/MayPointsToAnalysis.hpp"
+#include "MpaUtils.hpp"
+
+using namespace std;
+
+namespace llvm::noelle {
+
+MpaSummary::MpaSummary(Function *currentF) : currentF(currentF) {
+
+  auto insertPointer = [&](Value *v) {
+    if (v->getType()->isPointerTy()) {
+      pointers.insert(v);
+      auto stripped = strip(v);
+      if (stripped != v) {
+        pointers.insert(stripped);
+      }
+    }
+  };
+
+  /*
+   * 1. Collect store/alloca/malloc/calloc/free insts in the function.
+   * 2. Collect all pointers in the function.
+   * 3. Collect all pointers may be returned by the function.
+   */
+
+  for (auto &arg : currentF->args()) {
+    insertPointer(&arg);
+  }
+
+  for (auto &bb : *currentF) {
+    for (auto &inst : bb) {
+      if (isa<LoadInst>(inst)) {
+        auto loadInst = dyn_cast<LoadInst>(&inst);
+        insertPointer(loadInst->getPointerOperand());
+        insertPointer(loadInst);
+      } else if (isa<StoreInst>(inst)) {
+        auto storeInst = dyn_cast<StoreInst>(&inst);
+        storeInsts.insert(storeInst);
+        insertPointer(storeInst->getValueOperand());
+        insertPointer(storeInst->getPointerOperand());
+      } else if (isa<BitCastInst>(inst) || isa<GetElementPtrInst>(inst)) {
+        insertPointer(&inst);
+      } else if (isa<AllocaInst>(inst)) {
+        auto allocaInst = dyn_cast<AllocaInst>(&inst);
+        allocaInsts.insert(allocaInst);
+        insertPointer(allocaInst);
+      } else if (isa<CallBase>(inst)) {
+        auto callInst = dyn_cast<CallBase>(&inst);
+        auto calleeType = getCalleeFunctionType(callInst);
+        switch (calleeType) {
+          case MALLOC:
+            mallocInsts.insert(callInst);
+            insertPointer(callInst);
+            break;
+          case CALLOC:
+            callocInsts.insert(callInst);
+            insertPointer(callInst);
+            break;
+          case FREE:
+            freeInsts.insert(callInst);
+            break;
+          case REALLOC:
+            insertPointer(callInst);
+            break;
+          default:
+            insertPointer(callInst);
+            for (auto &arg : callInst->arg_operands()) {
+              auto operand = callInst->getArgOperand(arg.getOperandNo());
+              insertPointer(operand);
+            }
+            break;
+        }
+      } else if (isa<ReturnInst>(inst)) {
+        auto returnInst = dyn_cast<ReturnInst>(&inst);
+        auto retVal = returnInst->getReturnValue();
+        if (retVal && retVal->getType()->isPointerTy()) {
+          returnPointers.insert(retVal);
+        }
+      }
+    }
+  }
+}
+
+unordered_set<Value *> MpaSummary::getPointees(Value *ptr) {
+  assert(mpaFinished);
+  assert(ptr2nodeId.find(ptr) != ptr2nodeId.end());
+  auto ptrId = ptr2nodeId[ptr];
+  unordered_set<Value *> pointees;
+  for (auto memobjId : getPointees(ptrId).set_bits()) {
+    if (memobjId == UnknownMemobjId) {
+      pointees.insert(nullptr);
+    } else {
+      pointees.insert(nodeId2memobj.at(memobjId));
+    }
+  }
+  return pointees;
+}
+
+bool MpaSummary::mayBePointedByUnknown(Value *ptr) {
+  assert(mpaFinished);
+
+  auto pointedByUnknown = [this](NodeID nodeId) -> bool {
+    auto unknownPts = this->getReachableMemobjs(this->UnknownMemobjId);
+    if (unknownPts.find(nodeId) != unknownPts.end()) {
+      return true;
+    }
+    for (auto retPtr : this->returnPointers) {
+      auto retPtrId = getPtrId(retPtr);
+      auto retMemobjs = getReachableMemobjs(retPtrId);
+      if (retMemobjs.find(nodeId) != retMemobjs.end()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  if (ptr && isa<GlobalVariable>(ptr)) {
+    auto globalVar = dyn_cast<GlobalVariable>(ptr);
+    allocaCandidate = globalVar;
+    mayPointsToAnalysis();
+    auto memObjId = memobj2nodeId[globalVar];
+    return pointedByUnknown(memObjId);
+  } else if (ptr && getAllocations().count(ptr) > 0) {
+    if (!mpaFinished) {
+      allocaCandidate = nullptr;
+      mayPointsToAnalysis();
+    }
+    auto inst = dyn_cast<Instruction>(ptr);
+    auto memObjId = memobj2nodeId[inst];
+    return pointedByUnknown(memObjId);
+  } else {
+    assert(false && "Not a valid allocation of memory object.");
+  }
+}
+
+BitVector MpaSummary::getPointees(NodeID nodeId) {
+  if (pointsTo.find(nodeId) != pointsTo.end()) {
+    return pointsTo[nodeId];
+  } else {
+    return getEmptyBitVector();
+  }
+}
+
+unordered_set<NodeID> MpaSummary::getReachableMemobjs(NodeID ptrId) {
+  unordered_set<NodeID> reachable;
+  queue<NodeID> todolist;
+  todolist.push(ptrId);
+  while (!todolist.empty()) {
+    auto nodeId = todolist.front();
+    todolist.pop();
+
+    for (auto memObj : getPointees(nodeId).set_bits()) {
+      if (reachable.find(memObj) == reachable.end()) {
+        reachable.insert(memObj);
+        todolist.push(memObj);
+      }
+    }
+  }
+  return reachable;
+}
+
+BitVector MpaSummary::getEmptyBitVector(void) {
+  auto bitVecSize = 1 + getAllocations().size();
+  return BitVector(bitVecSize, false);
+}
+
+BitVector MpaSummary::onlyPointsTo(NodeID memobjId) {
+  auto emptyPts = getEmptyBitVector();
+  assert(memobjId >= 0 && memobjId < emptyPts.size());
+  emptyPts.set(memobjId);
+  return emptyPts;
+}
+
+unordered_set<Value *> MpaSummary::getAllocations(void) {
+  unordered_set<Value *> allocations;
+  for (auto &allocaInst : allocaInsts) {
+    allocations.insert(allocaInst);
+  }
+  for (auto &mallocInst : mallocInsts) {
+    allocations.insert(mallocInst);
+  }
+  for (auto &callocInst : callocInsts) {
+    allocations.insert(callocInst);
+  }
+  if (allocaCandidate) {
+    allocations.insert(allocaCandidate);
+  }
+  return allocations;
+}
+
+NodeID MpaSummary::getPtrId(Value *v) {
+  assert(v->getType()->isPointerTy());
+  auto stripped = strip(v);
+  if (ptr2nodeId.find(stripped) == ptr2nodeId.end()) {
+    ptr2nodeId[stripped] = nextNodeId++;
+  }
+  return ptr2nodeId[stripped];
+}
+
+bool MpaSummary::addCopyEdge(NodeID src, NodeID dst) {
+  return copyOutEdges[src].insert(dst).second;
+}
+
+void MpaSummary::mayPointsToAnalysis(void) {
+  initPtInfo();
+  solveWorklist();
+  mpaFinished = true;
+}
+
+void MpaSummary::initPtInfo(void) {
+
+  mpaFinished = false;
+  nextNodeId = 1;
+  ptr2nodeId.clear();
+  memobj2nodeId.clear();
+  nodeId2memobj.clear();
+  pointsTo.clear();
+  copyOutEdges.clear();
+  incomingStores.clear();
+  outgoingLoads.clear();
+  usedAsFuncArg.clear();
+
+  auto allocations = getAllocations();
+
+  /*
+   * Assign node ids to memory objects
+   * 1. Unknown memobj refers to all memobjs allocated in other functions
+   *    and memobjs of global variables. It's nodeId is always 0.
+   * 2. For each memobj allocated by alloca/malloc/calloc, assign a unique
+   *    nodeId.
+   * 3. If a global variable is allocaCandidate, its memobj is not unknown,
+   *    it will be assigned a unique nodeId.
+   */
+  nodeId2memobj[UnknownMemobjId] = nullptr;
+  memobj2nodeId[nullptr] = UnknownMemobjId;
+
+  for (auto &ptr : allocations) {
+    auto nodeId = nextNodeId++;
+    nodeId2memobj[nodeId] = ptr;
+    memobj2nodeId[ptr] = nodeId;
+  }
+
+  /*
+   * 1. Assign nodeId to each pointer.
+   * NOTE: The nodeId for the pointer is different from the nodeId for the
+   * memobj. For example, if we have %1 = alloca i32, the nodeId for the
+   * allocated memobj may be 1, the nodeId for the pointer %1 may be 4.
+   *
+   * 2. Initialize points-to information
+   * The unknown memobj conservatively points to itself since it's a summary.
+   * Pointers of alloca/malloc/calloc point to the allocated memobj. Arguments
+   * of current function, global variables and returned pointers of callInsts
+   * will point to unknown memobj (allocaCandidate is the only exception).
+   *
+   * 3. Add copy edges for pointers.
+   * Copy edges between pointers can be added through PHINode, SelectInst,
+   * MemcpyInst and realloc(). "unknown" memobj can be have copy edges from
+   * arguments of callInsts, and copy edges to returned pointers of callInsts.
+   *
+   * 4. Record uses of pointers.
+   * If a pointer is used as the pointer operand of a store/load instruction,
+   * or it is used as an argument of a callInst, record these uses since they
+   * can help the may points-to analysis add more copy edges.
+   */
+  pointsTo[UnknownMemobjId] = onlyPointsTo(UnknownMemobjId);
+
+  for (auto &ptr : pointers) {
+    auto ptrId = getPtrId(ptr);
+
+    if (allocations.find(ptr) != allocations.end()) {
+      auto memobjId = memobj2nodeId[ptr];
+      pointsTo[ptrId] = onlyPointsTo(memobjId);
+    } else if (isa<PHINode>(ptr)) {
+      auto phiNode = dyn_cast<PHINode>(ptr);
+      for (auto &incoming : phiNode->incoming_values()) {
+        auto incomingPtrId = getPtrId(incoming);
+        addCopyEdge(incomingPtrId, ptrId);
+      }
+    } else if (isa<SelectInst>(ptr)) {
+      auto selectInst = dyn_cast<SelectInst>(ptr);
+      auto trueValuePtrId = getPtrId(selectInst->getTrueValue());
+      auto falseValuePtrId = getPtrId(selectInst->getFalseValue());
+      addCopyEdge(trueValuePtrId, ptrId);
+      addCopyEdge(falseValuePtrId, ptrId);
+    } else if (isa<Argument>(ptr) || isa<GlobalVariable>(ptr)) {
+      pointsTo[ptrId] = onlyPointsTo(UnknownMemobjId);
+    } else if (isa<CallBase>(ptr)) {
+      auto callInst = dyn_cast<CallBase>(ptr);
+      auto calleeType = getCalleeFunctionType(callInst);
+      switch (calleeType) {
+        case REALLOC:
+          addCopyEdge(getPtrId(callInst->getArgOperand(0)), ptrId);
+          break;
+        case USER_DEFINED:
+        case UNKNOWN:
+          pointsTo[ptrId] = onlyPointsTo(UnknownMemobjId);
+          addCopyEdge(UnknownMemobjId, ptrId);
+          break;
+        default:
+          break;
+      }
+    } else if (isa<ConstantPointerNull>(ptr)) {
+      pointsTo[ptrId] = getEmptyBitVector();
+    }
+
+    for (auto user : ptr->users()) {
+      if (isa<StoreInst>(user)) {
+        auto storeInst = dyn_cast<StoreInst>(user);
+        auto valueOperand = storeInst->getValueOperand();
+        if (ptr == storeInst->getPointerOperand()
+            && valueOperand->getType()->isPointerTy()) {
+          incomingStores[ptrId].insert(storeInst);
+        }
+      } else if (isa<LoadInst>(user)) {
+        auto loadInst = dyn_cast<LoadInst>(user);
+        if (ptr == loadInst->getPointerOperand()
+            && loadInst->getType()->isPointerTy()) {
+          outgoingLoads[ptrId].insert(loadInst);
+        }
+      } else if (isa<CallBase>(user)) {
+        auto callInst = dyn_cast<CallBase>(user);
+        auto calleeType = getCalleeFunctionType(callInst);
+        switch (calleeType) {
+          case MEM_COPY:
+            addCopyEdge(getPtrId(callInst->getArgOperand(1)),
+                        getPtrId(callInst->getArgOperand(0)));
+            break;
+          case USER_DEFINED:
+          case UNKNOWN:
+            usedAsFuncArg.insert(ptrId);
+            addCopyEdge(ptrId, UnknownMemobjId);
+          default:
+            break;
+        }
+      }
+    }
+  }
+}
+
+void MpaSummary::solveWorklist(void) {
+  worklist = {};
+  for (auto &[ptr, ptrId] : ptr2nodeId) {
+    worklist.push(ptrId);
+  }
+
+  while (!worklist.empty()) {
+    auto nodeID = worklist.front();
+    worklist.pop();
+    handleLoadStore(nodeID);
+    handleFuncUsers(nodeID);
+    handleCopyEdges(nodeID);
+  }
+}
+
+void MpaSummary::handleLoadStore(NodeID ptrId) {
+  auto pointees = getPointees(ptrId);
+  for (auto memobjId : pointees.set_bits()) {
+    /*
+     * OutgoingLoads help us add new copy edges.
+     *
+     * For example, if pointers (%p2) and memobjs (@M1, @M2, @M3, @M4)
+     * form this points-to graph:
+     *
+     * %p2 -> @M2, @M3; @M2 -> @M1; @M3 -> @M4,
+     *
+     * then `%3 = load i32*, i32** %p2` can add copy edges
+     * "@M2 => %3" and "@M3 => %3"
+     *
+     * %3 will point to @M1 and @M4.
+     */
+    if (outgoingLoads.find(ptrId) != outgoingLoads.end()) {
+      for (auto loadInst : outgoingLoads[ptrId]) {
+        auto destId = getPtrId(loadInst);
+        if (addCopyEdge(memobjId, destId)) {
+          worklist.push(memobjId);
+        }
+      }
+    }
+
+    /*
+     * IncomingStores help us add new copy edges.
+     *
+     * For example, if pointers (%p1, %p2) and memobjs (@M1, @M2, @M3)
+     * form this points-to graph:
+     *
+     * %p1 -> @M1 ; %p2 -> @M2, @M3
+     *
+     * Then `store i32* %p1, i32** %p2` add copy edges "%p1 => @M2" and
+     * "%p1 => @M3", and the points-to graph can be updated:
+     *
+     * ... ; @M2 -> @M1; @M3 -> @M1
+     */
+    if (incomingStores.find(ptrId) != incomingStores.end()) {
+      for (auto storeInst : incomingStores[ptrId]) {
+        auto srcId = getPtrId(storeInst->getValueOperand());
+        if (addCopyEdge(srcId, memobjId)) {
+          worklist.push(srcId);
+        }
+      }
+    }
+  }
+}
+
+void MpaSummary::handleFuncUsers(NodeID ptrId) {
+  if (usedAsFuncArg.find(ptrId) == usedAsFuncArg.end()) {
+    return;
+  }
+  /*
+   * If a pointer is used as argument of a callInst, then all memobjds
+   * reachable from this pointer escape. To preserve conservativeness,
+   * "unknown" memobj and all escaped memobj point to each other.
+   *
+   * 1. Add copy edge between "unknown" memobj and all escaped memobjds.
+   * If memobj @M2 escaped and its points-to info updated:
+   *    pts(@M2) = ... U { @M1 },
+   * such an update should be propagated because @M1 escaped too:
+   *    pts("unknown") = ... U { @M1 }.
+   *
+   * 2. Add copy edge from the pointer argument to "unknown" memobj.
+   * Assume pointer %p1 is used as argument of a callInst `call @g(%p1)`,
+   * and we have this points-to graph:
+   *    %p1 -> @M1, @M2 ; @M1 -> @M3, @M4
+   * Adding copy edges between "unknown" memobj and { @M1, @M2, @M3, @M4 }
+   * is not enough because @M1 and @M2 are not pointed by any escaped memobj.
+   * Hence "unknown" memobj will not point to @M1 and @M2. To solve this issue,
+   * we need also to add copy edges from  %p1 to "unknown" memobj so that
+   * "unkonwn" can point to @M1 and @M2.
+   *
+   * 3. Add copy edge from "unknown" memobj to the return value.
+   * If the return value of the callInst is a pointer, it will conservatively
+   * point to "unknown" memobj and all escaped memobj.
+   *
+   * Here we only handle case 1. Case 2 and 3 are already handled by
+   * initPtInfo().
+   */
+  for (auto memobjId : getReachableMemobjs(ptrId)) {
+    bool changed = false;
+    changed |= addCopyEdge(memobjId, UnknownMemobjId);
+    changed |= addCopyEdge(UnknownMemobjId, memobjId);
+    if (changed) {
+      worklist.push(memobjId);
+    }
+  }
+}
+
+void MpaSummary::handleCopyEdges(NodeID srcId) {
+  if (copyOutEdges.find(srcId) == copyOutEdges.end()) {
+    return;
+  }
+  /*
+   * Propogate the points-to info from srcId to destId through copy edges.
+   * i.e. pts(destId) = pts(destId) U pts(srcId).
+   * If pts(destId) is changed, add destId to worklist.
+   */
+  for (auto &destId : copyOutEdges[srcId]) {
+    if (unionPts(srcId, destId)) {
+      worklist.push(destId);
+    }
+  }
+}
+
+bool MpaSummary::unionPts(NodeID srcId, NodeID dstId) {
+  BitVector oldPts = pointsTo[dstId];
+  BitVector newPts = unite(oldPts, pointsTo[srcId]);
+  if (oldPts == newPts) {
+    return false;
+  } else {
+    pointsTo[dstId] = newPts;
+    return true;
+  }
+}
+
+} // namespace llvm::noelle

--- a/src/core/may_points_to_analysis/src/MpaSummary.cpp
+++ b/src/core/may_points_to_analysis/src/MpaSummary.cpp
@@ -146,22 +146,6 @@ unordered_set<Value *> MpaSummary::getPointeeMemobjs(Value *ptr) {
   return pointees;
 }
 
-unordered_set<Value *> MpaSummary::getReachableMemobjs(Value *ptr) {
-  assert(mpaFinished);
-
-  auto stripped = strip(ptr);
-  assert(ptr2nodeId.find(stripped) != ptr2nodeId.end());
-
-  auto ptrId = ptr2nodeId[stripped];
-  unordered_set<Value *> reachable;
-
-  auto reachableMemobjIds = getreachableMemobjIds(ptrId);
-  for (auto memobjId : reachableMemobjIds) {
-    reachable.insert(nodeId2memobj[memobjId]);
-  }
-  return reachable;
-}
-
 bool MpaSummary::mayBePointedByUnknown(Value *memobj) {
   assert(mpaFinished);
   assert(getAllocations().count(memobj) > 0);

--- a/src/core/may_points_to_analysis/src/MpaUtils.cpp
+++ b/src/core/may_points_to_analysis/src/MpaUtils.cpp
@@ -95,4 +95,20 @@ BitVector unite(const BitVector &lhs, const BitVector &rhs) {
   return result;
 }
 
+bool isAllocation(Instruction *allocation) {
+  if (isa<AllocaInst>(allocation)) {
+    return true;
+  }
+
+  if (isa<CallBase>(allocation)) {
+    auto callInst = dyn_cast<CallBase>(allocation);
+    auto calleeType = getCalleeFunctionType(callInst);
+    if (calleeType == MALLOC || calleeType == CALLOC) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 } // namespace llvm::noelle

--- a/src/core/may_points_to_analysis/src/MpaUtils.cpp
+++ b/src/core/may_points_to_analysis/src/MpaUtils.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Xiao Chen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "MpaUtils.hpp"
+
+using namespace std;
+
+namespace llvm::noelle {
+
+MPAFunctionType getCalleeFunctionType(CallBase *callInst) {
+  const set<string> READ_ONLY_LIB_FUNCTIONS = {
+    "atoi",   "atof",    "atol",   "atoll",  "fprintf", "fputc", "fputs",
+    "putc",   "putchar", "printf", "puts",   "rand",    "scanf", "sqrt",
+    "strlen", "strncmp", "strtod", "strtol", "strtoll"
+  };
+
+  const set<string> READ_ONLY_LIB_FUNCTIONS_WITH_SUFFIX = [&]() -> set<string> {
+    set<string> result;
+    for (auto fname : READ_ONLY_LIB_FUNCTIONS) {
+      result.insert(fname);
+      result.insert(fname + "_unlocked");
+    }
+    return result;
+  }();
+
+  auto isLifetimeIntrinsic = [](CallBase *callInst) {
+    auto intrinsic = dyn_cast<IntrinsicInst>(callInst);
+    if (!intrinsic) {
+      return false;
+    }
+    return intrinsic->isLifetimeStartOrEnd();
+  };
+
+  auto calleeFunc = callInst->getCalledFunction();
+  auto fname = calleeFunc ? calleeFunc->getName() : "";
+
+  if (fname == "malloc") {
+    return MALLOC;
+  } else if (fname == "calloc") {
+    return CALLOC;
+  } else if (fname == "realloc") {
+    return REALLOC;
+  } else if (fname == "free") {
+    return FREE;
+  } else if (isLifetimeIntrinsic(callInst)) {
+    return INTRINSIC;
+  } else if (READ_ONLY_LIB_FUNCTIONS_WITH_SUFFIX.count(fname) > 0) {
+    return READ_ONLY;
+  } else if (isa<MemCpyInst>(callInst)) {
+    return MEM_COPY;
+  } else if ((calleeFunc != nullptr) && (!calleeFunc->isDeclaration())) {
+    return USER_DEFINED;
+  } else {
+    return UNKNOWN;
+  }
+}
+
+Value *strip(Value *pointer) {
+  assert(pointer != nullptr || pointer->getType()->isPointerTy());
+
+  if (isa<GetElementPtrInst>(pointer)) {
+    auto gepInst = dyn_cast<GetElementPtrInst>(pointer);
+    return strip(gepInst->getPointerOperand());
+  } else if (isa<GEPOperator>(pointer)) {
+    auto gepOp = dyn_cast<GEPOperator>(pointer);
+    return strip(gepOp->getPointerOperand());
+  } else if (isa<BitCastInst>(pointer) || isa<BitCastOperator>(pointer)) {
+    return strip(pointer->stripPointerCasts());
+  } else {
+    return pointer;
+  }
+}
+
+BitVector unite(const BitVector &lhs, const BitVector &rhs) {
+  BitVector result(lhs);
+  result |= rhs;
+  return result;
+}
+
+} // namespace llvm::noelle

--- a/src/core/may_points_to_analysis/src/MpaUtils.hpp
+++ b/src/core/may_points_to_analysis/src/MpaUtils.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Xiao Chen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "noelle/core/Utils.hpp"
+
+namespace llvm::noelle {
+
+enum MPAFunctionType {
+  MALLOC,
+  CALLOC,
+  REALLOC,
+  FREE,
+  INTRINSIC,
+  READ_ONLY,
+  MEM_COPY,
+  USER_DEFINED,
+  UNKNOWN
+};
+
+MPAFunctionType getCalleeFunctionType(CallBase *callInst);
+
+/*
+ * Strip pointer casts and GEPs.
+ */
+Value *strip(Value *pointer);
+
+BitVector unite(const BitVector &lhs, const BitVector &rhs);
+
+} // namespace llvm::noelle

--- a/src/core/may_points_to_analysis/src/MpaUtils.hpp
+++ b/src/core/may_points_to_analysis/src/MpaUtils.hpp
@@ -46,4 +46,6 @@ Value *strip(Value *pointer);
 
 BitVector unite(const BitVector &lhs, const BitVector &rhs);
 
+bool isAllocation(Instruction *allocation);
+
 } // namespace llvm::noelle

--- a/src/core/noelle/include/noelle/core/Noelle.hpp
+++ b/src/core/noelle/include/noelle/core/Noelle.hpp
@@ -42,6 +42,7 @@
 #include "noelle/core/CFGTransformer.hpp"
 #include "noelle/core/Linker.hpp"
 #include "noelle/core/AliasAnalysisEngine.hpp"
+#include "noelle/core/MayPointsToAnalysis.hpp"
 
 namespace llvm::noelle {
 
@@ -193,6 +194,8 @@ public:
   DataFlowEngine getDataFlowEngine(void) const;
 
   Scheduler getScheduler(void) const;
+
+  MayPointsToAnalysis getMayPointsToAnalysis(void) const;
 
   LoopTransformer &getLoopTransformer(void);
 

--- a/src/core/noelle/src/CMakeLists.txt
+++ b/src/core/noelle/src/CMakeLists.txt
@@ -53,6 +53,7 @@ include_directories(${LLVM_INCLUDE_DIRS}
   ../../compilation_options_manager/include
   ../../functions_manager/include
   ../../globals_manager/include
+  ../../may_points_to_analysis/include
   ${CMAKE_INSTALL_PREFIX}/include
   )
 

--- a/src/core/noelle/src/Noelle.cpp
+++ b/src/core/noelle/src/Noelle.cpp
@@ -125,6 +125,10 @@ Scheduler Noelle::getScheduler(void) const {
   return Scheduler{};
 }
 
+MayPointsToAnalysis Noelle::getMayPointsToAnalysis(void) const {
+  return MayPointsToAnalysis{};
+}
+
 LoopTransformer &Noelle::getLoopTransformer(void) {
   auto &lt = getAnalysis<LoopTransformer>();
   auto pdg = this->getProgramDependenceGraph();

--- a/src/core/pdg_analysis/include/noelle/core/PDGAnalysis.hpp
+++ b/src/core/pdg_analysis/include/noelle/core/PDGAnalysis.hpp
@@ -29,6 +29,7 @@
 #include "noelle/core/PDG.hpp"
 #include "noelle/core/CallGraph.hpp"
 #include "noelle/core/AliasAnalysisEngine.hpp"
+#include "noelle/core/MayPointsToAnalysis.hpp"
 
 namespace llvm::noelle {
 
@@ -64,6 +65,7 @@ private:
   Module *M;
   PDG *programDependenceGraph;
   AllocAA *allocAA;
+  MayPointsToAnalysis mpa;
   TalkDown *talkdown;
   DataFlowAnalysis dfa;
   PDGVerbosity verbose;

--- a/src/core/scripts/noelle-load
+++ b/src/core/scripts/noelle-load
@@ -36,7 +36,7 @@ fi
 
 
 ########### NOELLE analyses
-PDGPASS="-load ${installDir}/lib/AllocAA.so -load ${installDir}/lib/AliasAnalysisEngine.so -load ${installDir}/lib/TalkDown.so -load ${installDir}/lib/CallGraph.so -load ${installDir}/lib/DG.so -load ${installDir}/lib/PDG.so -load ${installDir}/lib/SCCDAG.so -load ${installDir}/lib/PDGPrinter.so -load ${installDir}/lib/PDGAnalysis.so -load ${installDir}/lib/MemoryCloningAnalysis.so"
+PDGPASS="-load ${installDir}/lib/AllocAA.so -load ${installDir}/lib/AliasAnalysisEngine.so -load ${installDir}/lib/TalkDown.so -load ${installDir}/lib/CallGraph.so -load ${installDir}/lib/DG.so -load ${installDir}/lib/PDG.so -load ${installDir}/lib/SCCDAG.so -load ${installDir}/lib/PDGPrinter.so -load ${installDir}/lib/MayPointsToAnalysis.so -load ${installDir}/lib/PDGAnalysis.so -load ${installDir}/lib/MemoryCloningAnalysis.so"
 
 
 ########### All analyses

--- a/tests/condor/bin/runRegression.sh
+++ b/tests/condor/bin/runRegression.sh
@@ -18,6 +18,13 @@ errorFile="$8" ;
 source ~/.bash_profile ;
 cd $repoDir/ ;
 
+if ! test -e $testDir ; then
+  fileName="TestDir_not_exists_`echo ${testDir} | tr -s '/' '_'`" ;
+  echo "TestDir not exists : $testDir" > ${fileName}.txt ;
+  echo "RepoDir : $repoDir" >> ${fileName}.txt ;
+  exit 0 ;
+fi
+
 # Go to the directory
 cd $testDir ;
 


### PR DESCRIPTION
1. Add an intra-procedural, flow-insensitive, field-insensitive may-points-to-analysis in src/core/may_points_to_analysis.
2. In src/core/pdg_analysis, replace AllocAA with this may-points-to-analysis to check alias info more precisely.
3. In src/core/pdg_analysis, remove some over-conservative dependences between LoadInst and print functions.
4. In tests/condor/bin/runRegression.sh, early quit if test case not exits.