### PR TITLE
Fix privatizer issue

### DIFF
--- a/src/tools/privatizer/include/Privatizer.hpp
+++ b/src/tools/privatizer/include/Privatizer.hpp
@@ -111,6 +111,7 @@ private:
                                                      GlobalVariable *globalVar);
 
   Instruction *getInitProgramPoint(Noelle &noelle,
+                                   DominatorSummary *DS,
                                    GlobalVariable *globalVar,
                                    StoreInst *storeInst,
                                    unordered_set<Instruction *> &initializers);

--- a/tests/regression/PrivatizerIssue/test.cpp
+++ b/tests/regression/PrivatizerIssue/test.cpp
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int globalArray[10];
+
+int main(int argc, char *argv[]) {
+  if (argc < 3) {
+    fprintf(stderr, "USAGE: x, y, z must be provided.\n");
+    return -1;
+  }
+
+  auto x = atoi(argv[1]);
+  auto y = atoi(argv[2]);
+  auto z = atoi(argv[3]);
+
+  for (int i = 0; i < 10; i++) {
+    globalArray[i] = x;
+    if (i > 3) {
+      printf("i>3\n");
+      globalArray[i] = y;
+      if (i < 7) {
+        printf("i<7\n");
+        globalArray[i] = z;
+      } else {
+        printf("i>=7\n");
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add the `PrivatizerIssue` testcase to trigger the incorrect logic in Privatizer::getInitProgramPoint, then add a fix.

To check that a global array is completely initialized, privatizer expects the following pattern, where the instruction `globalArray[i] = 20;` is called a initializer of `globalArray`.
```c
int globalArray[10];
void f() {
  for (int i = 0; i < 10; i++) {
    globalArray[i] = 20;
  }
}
```

Privatizer didn't check initializers rigorously enough so that it would say `globalArray2[i] = 40;` is also a initializer, which is incorrect because `globalArray2` is not completely initialized.
```c
int globalArray2[10];
void f() {
  for (int i = 0; i < 10; i++) {
    if (i > 7) {
      globalArray2[i] = 40;
    }
  }
}
```