### PR TITLE
Fixed bug with PeriodicVariableOutput regression test

### DIFF
--- a/src/tools/helix/src/HELIX_stepper.cpp
+++ b/src/tools/helix/src/HELIX_stepper.cpp
@@ -532,15 +532,17 @@ void HELIX::rewireLoopForPeriodicVariables(LoopDependenceInfo *LDI) {
     IRBuilder<> preheaderBuilder(preheaderClone->getTerminator());
 
     auto stepXiteration = preheaderBuilder.CreateMul(
-        stepSize,
-        preheaderBuilder.CreateZExtOrTrunc(task->coreArg, stepSize->getType()),
+        preheaderBuilder.CreateZExtOrTrunc(stepSize, task->coreArg->getType()),
+        task->coreArg,
         "stepXiteration");
     auto stepsModPeriod = preheaderBuilder.CreateSRem(
         stepXiteration,
         preheaderBuilder.CreateZExtOrTrunc(period, stepXiteration->getType()),
         "stepsModPeriod");
-    auto offsetStartValue =
-        preheaderBuilder.CreateAdd(initialValue, stepsModPeriod);
+    auto offsetStartValue = preheaderBuilder.CreateAdd(
+        initialValue,
+        preheaderBuilder.CreateZExtOrTrunc(stepsModPeriod,
+                                           initialValue->getType()));
 
     taskPHI->setIncomingValueForBlock(preheaderClone, offsetStartValue);
 


### PR DESCRIPTION
Bug with HELIX periodic variable logic when dealing with `i1` values, fixed.