### PR TITLE
[bug] Fixed a bug in loop environment

### DIFF
--- a/src/core/loop_environment/src/LoopEnvironment.cpp
+++ b/src/core/loop_environment/src/LoopEnvironment.cpp
@@ -274,7 +274,7 @@ uint64_t LoopEnvironment::getNumberOfLiveIns(void) const {
 }
 
 uint64_t LoopEnvironment::getNumberOfLiveOuts(void) const {
-  auto liveOuts = this->getEnvIDsOfLiveInVars();
+  auto liveOuts = this->getEnvIDsOfLiveOutVars();
   auto numberOfLiveOuts = std::distance(liveOuts.begin(), liveOuts.end());
   return numberOfLiveOuts;
 }


### PR DESCRIPTION
The wrong method gets called when getting the set of IDs of LiveOutVars.