### PR TITLE
[DG] DGEdge type size reduction from 48 bytes to 40 bytes

### DIFF
--- a/src/core/dg/include/noelle/core/DGEdge.hpp
+++ b/src/core/dg/include/noelle/core/DGEdge.hpp
@@ -100,10 +100,10 @@ protected:
   DGEdge(const DGEdge<T, SubT> &edgeToCopy);
 
 private:
-  DependenceKind kind;
   DGNode<T> *from;
   DGNode<T> *to;
   std::unordered_set<DGEdge<SubT, SubT> *> *subEdges;
+  DependenceKind kind;
   bool isLoopCarried;
 };
 


### PR DESCRIPTION
The smallest-at-the-end rule strikes again