### PR TITLE
add generalization for dataflow engine applying both forward and back…

### DIFF
--- a/src/core/dataflow/include/noelle/core/DataFlowEngine.hpp
+++ b/src/core/dataflow/include/noelle/core/DataFlowEngine.hpp
@@ -115,6 +115,31 @@ private:
           appendBB,
       std::function<Instruction *(BasicBlock *bb)> getFirstInstruction,
       std::function<Instruction *(BasicBlock *bb)> getLastInstruction);
+
+  DataFlowResult *applyGeneralizedAnalysis(
+    Function *f,
+    std::function<void(Instruction *, DataFlowResult *)> computeGEN,
+    std::function<void(Instruction *, DataFlowResult *)> computeKILL,
+    std::function<void(Instruction *inst, std::set<Value *> &IN)> initializeIN,
+    std::function<void(Instruction *inst, std::set<Value *> &OUT)>
+        initializeOUT,
+    std::function< std::list<BasicBlock *> (BasicBlock *bb)> getPredecessors,
+    std::function< std::list<BasicBlock *> (BasicBlock *bb)> getSuccessors,
+    std::function<void(Instruction *inst,
+                       Instruction *predecessor,
+                       std::set<Value *> &IN,
+                       DataFlowResult *df)> computeIN,
+    std::function<void(Instruction *inst,
+                       std::set<Value *> &OUT,
+                       DataFlowResult *df)> computeOUT,
+    std::function<void(std::list<BasicBlock *> &workingList, BasicBlock *bb)>
+        appendBB,
+    std::function<Instruction *(BasicBlock *bb)> getFirstInstruction,
+    std::function<Instruction *(BasicBlock *bb)> getLastInstruction,
+    std::function<std::set<Value *> & (DataFlowResult * df, Instruction * instruction)> getInSetOfInst, 
+    std::function<std::set<Value *> & (DataFlowResult * df, Instruction * instruction)> getOutSetOfInst,
+    std::function<BasicBlock::iterator(BasicBlock*)> getEndIterator,
+    std::function<void(BasicBlock::iterator&)>  incrementIterator );
 };
 
 } // namespace arcana::noelle

--- a/src/core/dataflow/src/DataFlowEngine.cpp
+++ b/src/core/dataflow/src/DataFlowEngine.cpp
@@ -89,20 +89,58 @@ DataFlowResult *DataFlowEngine::applyForward(
     return bb->getTerminator();
   };
 
-  /*
+  auto getPredecessors = [](BasicBlock *bb) -> std::list<BasicBlock *> {
+    std::list<BasicBlock*> Predecessors; 
+    for (auto predecessor : predecessors(bb)){
+      Predecessors.push_back(predecessor);
+    }
+    return Predecessors;
+  }; 
+
+  auto getSuccessors = [](BasicBlock *bb) -> std::list<BasicBlock *> {
+    std::list<BasicBlock*> Successors; 
+    for (auto predecessor : successors(bb)){
+      Successors.push_back(predecessor);
+    }
+    return Successors;
+  }; 
+
+   auto inSetOfInst = [](DataFlowResult * df, Instruction * inst) -> std::set<Value *> & { 
+    return df->IN(inst); 
+  };
+
+  auto outSetOfInst = [](DataFlowResult * df, Instruction * inst) -> std::set<Value *> & { 
+    return df->OUT(inst); 
+  };
+
+  auto getEndIterator = [](BasicBlock* bb) -> BasicBlock::iterator { 
+    return bb->end(); 
+  };
+
+  auto incrementIterator = [](BasicBlock::iterator& iter) { 
+    iter++; 
+  };
+
+
+ /*
    * Run the pass.
    */
-  auto dfaResult = this->applyCustomizableForwardAnalysis(f,
+  auto dfaResult = this->applyGeneralizedAnalysis(f,
                                                           computeGEN,
                                                           computeKILL,
                                                           initializeIN,
                                                           initializeOUT,
+                                                          getPredecessors,
+                                                          getSuccessors,
                                                           computeIN,
                                                           computeOUT,
                                                           appendBB,
                                                           getFirstInst,
-                                                          getLastInst);
-
+                                                          getLastInst, 
+                                                          inSetOfInst, 
+                                                          outSetOfInst,
+                                                          getEndIterator,
+                                                          incrementIterator);
   return dfaResult;
 }
 
@@ -142,126 +180,83 @@ DataFlowResult *DataFlowEngine::applyBackward(
                        Instruction *successor,
                        std::set<Value *> &OUT,
                        DataFlowResult *df)> computeOUT) {
-
   /*
-   * Compute the GENs and KILLs
+   * Define the customization
    */
-  auto df = new DataFlowResult{};
-  computeGENAndKILL(f, computeGEN, computeKILL, df);
+  auto appendBB = [](std::list<BasicBlock *> &workingList, BasicBlock *bb) {
+    workingList.push_back(bb);
+  };
 
-  /*
-   * Compute the IN and OUT
-   *
-   * Create the working list by adding all basic blocks to it.
-   */
-  std::unordered_set<BasicBlock *> computedOnce;
-  std::list<BasicBlock *> workingList;
-  for (auto &bb : *f) {
-    workingList.push_front(&bb);
-  }
-
-  /*
-   * Compute the INs and OUTs iteratively until the working list is empty.
-   */
-  while (!workingList.empty()) {
-
-    /*
-     * Fetch a basic block that needs to be processed.
-     */
-    auto bb = workingList.front();
-    workingList.pop_front();
-
-    /*
-     * Fetch the last instruction of the current basic block.
-     */
-    auto inst = bb->getTerminator();
-    assert(inst != nullptr);
-
-    /*
-     * Fetch IN[inst], OUT[inst], GEN[inst], and KILL[inst]
-     */
-    auto &inSetOfInst = df->IN(inst);
-    auto &outSetOfInst = df->OUT(inst);
-
-    /*
-     * Compute OUT[inst]
-     */
-    for (auto successorBB : successors(bb)) {
-
-      /*
-       * Fetch the current successor of "inst".
-       */
-      auto successorInst = &*successorBB->begin();
-
-      /*
-       * Compute OUT[inst]
-       */
-      computeOUT(inst, successorInst, outSetOfInst, df);
+  auto getPredecessors = [](BasicBlock *bb) -> std::list<BasicBlock *> {
+    std::list<BasicBlock*> Successors; 
+    for (auto predecessor : successors(bb)){
+      Successors.push_back(predecessor);
     }
+    return Successors;
+  }; 
 
-    /*
-     * Compute IN[inst]
-     */
-    auto oldSize = inSetOfInst.size();
-    computeIN(inst, inSetOfInst, df);
-
-    /*
-     * Check if IN[inst] changed.
-     */
-    if ((inSetOfInst.size() > oldSize)
-        || (computedOnce.find(bb) == computedOnce.end())) {
-
-      /*
-       * Remember that we have now computed this basic block.
-       */
-      computedOnce.insert(bb);
-
-      /*
-       * Propagate the new IN[inst] to the rest of the instructions of the
-       * current basic block.
-       */
-      BasicBlock::iterator iter(inst);
-      auto succI = cast<Instruction>(inst);
-      while (iter != bb->begin()) {
-
-        /*
-         * Move the iterator.
-         */
-        iter--;
-
-        /*
-         * Fetch the current instruction.
-         */
-        auto i = &*iter;
-
-        /*
-         * Compute OUT[i]
-         */
-        auto &outSetOfI = df->OUT(i);
-        computeOUT(i, succI, outSetOfI, df);
-
-        /*
-         * Compute IN[i]
-         */
-        auto &inSetOfI = df->IN(i);
-        computeIN(i, inSetOfI, df);
-
-        /*
-         * Update the successor.
-         */
-        succI = i;
-      }
-
-      /*
-       * Add predecessors of the current basic block to the working list.
-       */
-      for (auto predBB : predecessors(bb)) {
-        workingList.push_back(predBB);
-      }
+  auto getSuccessors = [](BasicBlock *bb) -> std::list<BasicBlock *> {
+    std::list<BasicBlock*> Predecessors; 
+    for (auto predecessor : predecessors(bb)){
+      Predecessors.push_back(predecessor);
     }
-  }
+    return Predecessors;
+  }; 
 
-  return df;
+  auto getFirstInst = [](BasicBlock *bb) -> Instruction * {
+    return bb->getTerminator();
+  };
+
+  auto getLastInst = [](BasicBlock *bb) -> Instruction * {
+    return &*bb->begin();
+  };
+
+  auto initializeIN = [](Instruction *inst, std::set<Value *> &IN){
+    return; 
+  };
+
+  auto initializeOUT = [](Instruction *inst, std::set<Value *> &OUT){
+    return; 
+  };
+
+  auto inSetOfInst = [](DataFlowResult * df, Instruction * inst) -> std::set<Value *> & { 
+    return df->OUT(inst); 
+  };
+
+   auto outSetOfInst = [](DataFlowResult * df, Instruction * inst) -> std::set<Value *> &  { 
+    return df->IN(inst); 
+  };
+
+  auto getEndIterator = [](BasicBlock* bb) -> BasicBlock::iterator { 
+    return bb->begin(); 
+  };
+
+  auto incrementIterator = [](BasicBlock::iterator& iter) { 
+    iter--; 
+  };
+
+
+  /*
+   * Run the pass.
+   */
+  auto dfaResult = this->applyGeneralizedAnalysis(f,
+                                                          computeGEN,
+                                                          computeKILL,
+                                                          initializeIN,
+                                                          initializeOUT,
+                                                          getPredecessors,
+                                                          getSuccessors,
+                                                          computeOUT,
+                                                          computeIN,
+                                                          appendBB,
+                                                          getFirstInst,
+                                                          getLastInst, 
+                                                          inSetOfInst,
+                                                          outSetOfInst,
+                                                          getEndIterator,
+                                                          incrementIterator);
+
+  return dfaResult;
 }
 
 void DataFlowEngine::computeGENAndKILL(
@@ -440,6 +435,174 @@ DataFlowResult *DataFlowEngine::applyCustomizableForwardAnalysis(
   }
 
   return df;
+}
+
+DataFlowResult *DataFlowEngine::applyGeneralizedAnalysis(
+    Function *f,
+    std::function<void(Instruction *, DataFlowResult *)> computeGEN,
+    std::function<void(Instruction *, DataFlowResult *)> computeKILL,
+    std::function<void(Instruction *inst, std::set<Value *> &IN)> initializeIN,
+    std::function<void(Instruction *inst, std::set<Value *> &OUT)>
+        initializeOUT,
+    std::function< std::list<BasicBlock *> (BasicBlock *bb)> getPredecessors,
+    std::function< std::list<BasicBlock *> (BasicBlock *bb)> getSuccessors,
+    std::function<void(Instruction *inst,
+                       Instruction *predecessor,
+                       std::set<Value *> &IN,
+                       DataFlowResult *df)> computeIN,
+    std::function<void(Instruction *inst,
+                       std::set<Value *> &OUT,
+                       DataFlowResult *df)> computeOUT,
+    std::function<void(std::list<BasicBlock *> &workingList, BasicBlock *bb)>
+        appendBB,
+    std::function<Instruction *(BasicBlock *bb)> getFirstInstruction,
+    std::function<Instruction *(BasicBlock *bb)> getLastInstruction,
+    std::function<std::set<Value *> & (DataFlowResult * df, Instruction * instruction)> getInSetOfInst, 
+    std::function<std::set<Value *> & (DataFlowResult * df, Instruction * instruction)> getOutSetOfInst,
+    std::function<BasicBlock::iterator(BasicBlock*)> getEndIterator,
+    std::function<void(BasicBlock::iterator&)>  incrementIterator) {
+   
+  /*
+   * Initialize IN and OUT sets.
+   */
+  auto df = new DataFlowResult{};
+  for (auto &bb : *f) {
+    for (auto &i : bb) {
+      auto &INSet = df->IN(&i);
+      auto &OUTSet = df->OUT(&i);
+      initializeIN(&i, INSet);
+      initializeOUT(&i, OUTSet);
+    }
+  }
+
+  /*
+   * Compute the GENs and KILLs
+   */
+  computeGENAndKILL(f, computeGEN, computeKILL, df);
+
+  /*
+   * Compute the IN and OUT
+   *
+   * Create the working list by adding all basic blocks to it.
+   */
+  std::list<BasicBlock *> workingList;
+  std::unordered_map<BasicBlock *, bool> worklingListContent;
+  for (auto &bb : *f) {
+    appendBB(workingList, &bb);
+    worklingListContent[&bb] = true;
+  }
+
+  /*
+   * Compute the INs and OUTs iteratively until the working list is empty.
+   */
+  std::unordered_map<Instruction *, bool> alreadyVisited;
+
+  while (!workingList.empty()) {
+
+    /*
+     * Fetch a basic block that needs to be processed.
+     */
+    auto bb = workingList.front();
+    assert(worklingListContent[bb] == true);
+
+    /*
+     * Remove the basic block from the workingList.
+     */
+    workingList.pop_front();
+    worklingListContent[bb] = false;
+
+    /*
+     * Fetch the first instruction of the basic block.
+     */
+    auto inst = getFirstInstruction(bb);
+
+    /*
+     * Fetch IN[inst], OUT[inst], GEN[inst], and KILL[inst]
+     */
+    auto &inSetOfInst = getInSetOfInst(df, inst);
+    auto &outSetOfInst = getOutSetOfInst(df, inst);
+
+    /*
+     * Compute the IN of the first instruction of the current basic block.
+     */
+    for (auto predecessorBB : getPredecessors(bb)) {
+
+      /*
+       * Fetch the current predecessor of "inst".
+       */
+      auto predecessorInst = getLastInstruction(predecessorBB);
+
+      /*
+       * Compute IN[inst]
+       */
+      computeIN(inst, predecessorInst, inSetOfInst, df);
+    }
+
+    /*
+     * Compute OUT[inst]
+     */
+    auto oldSizeOut = outSetOfInst.size();
+    auto oldSizeIn = inSetOfInst.size(); 
+    computeOUT(inst, outSetOfInst, df);
+
+    /* Check if the OUT of the first instruction of the current basic block
+     * changed.
+     */
+    if (false || (!alreadyVisited[inst]) || (outSetOfInst.size() != oldSizeOut)
+       || (inSetOfInst.size() != oldSizeIn)) {
+      alreadyVisited[inst] = true;
+
+      /*
+       * Propagate the new OUT[inst] to the rest of the instructions of the
+       * current basic block.
+       */
+      BasicBlock::iterator iter(inst);
+      auto predI = inst;
+      while (iter != getEndIterator(bb)) {
+
+        /*
+         * Move the iterator.
+         */
+        incrementIterator(iter);
+
+        /*
+         * Fetch the current instruction.
+         */
+        auto i = &*iter;
+
+        /*
+         * Compute IN[i]
+         */
+        auto &inSetOfI = getInSetOfInst(df, i);
+        computeIN(i, predI, inSetOfI, df);
+
+        /*
+         * Compute OUT[i]
+         */
+        auto &outSetOfI = getOutSetOfInst(df, i);
+        computeOUT(i, outSetOfI, df);
+
+        /*
+         * Update the predecessor.
+         */
+        predI = i;
+      }
+
+      /*
+       * Add successors of the current basic block to the working list.
+       */
+      for (auto succBB : getSuccessors(bb)) {
+        if (worklingListContent[succBB] == true) {
+          continue;
+        }
+        workingList.push_back(succBB);
+        worklingListContent[succBB] = true;
+      }
+    }
+  }
+
+
+  return df ; 
 }
 
 } // namespace arcana::noelle


### PR DESCRIPTION
Changes I made:

1. Add a function `applyGeneralizedAnalysis` to generalize the data flow engine applying both forward and backward.
2. Change the api in `applyForward` from using `applyCustomizableForwardAnalysis` to using `applyGeneralizedAnalysis`.
3. Delete the body of the original `applyBackward` function, now it calls the function `applyGeneralizedAnalysis`.