### PR TITLE
Fixed recompilation issues for `v14`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,13 +26,6 @@ include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 link_directories(${LLVM_LIBRARY_DIRS})
 
-execute_process(
-  COMMAND llvm-config --obj-root
-  OUTPUT_VARIABLE LLVM_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_STRIP_TRAILING_WHITESPACE
-)
-
 FetchContent_Declare(
   svf
   GIT_REPOSITORY  "https://github.com/arcana-lab/SVF.git"
@@ -126,7 +119,7 @@ enable_language(C CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_INSTALL_PREFIX}")
 
 # prepare the pass to be included in the source tree
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,6 @@ set(NOELLE_CXX_FLAGS
 )
 
 find_package(LLVM 14 REQUIRED CONFIG)
-include_directories(${LLVM_INCLUDE_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
-link_directories(${LLVM_LIBRARY_DIRS})
 
 FetchContent_Declare(
   svf
@@ -83,10 +80,6 @@ if(NOELLE_SVF STREQUAL ON)
   include_directories(${svf_BINARY_DIR}/include)
   include_directories(${svf_SOURCE_DIR}/svf/include)
   include_directories(${svf_SOURCE_DIR}/svf-llvm/include)
-  set_property(
-    DIRECTORY ${svf_SOURCE_DIR}
-    PROPERTY CMAKE_BUILD_TYPE RelWithDebInfo
-  )
 endif()
 
 if(NOELLE_SCAF STREQUAL ON)
@@ -123,19 +116,12 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_INSTALL_PREFIX}")
 
 # prepare the pass to be included in the source tree
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-include(AddLLVM)
-include(HandleLLVMOptions)
 
 include_directories(
   ${LLVM_INCLUDE_DIRS}
 )
 
 add_compile_options(${NOELLE_CXX_FLAGS})
-
-add_definitions(
-  -D__STDC_LIMIT_MACROS
-  -D__STDC_CONSTANT_MACROS
-)
 
 add_custom_target(
   CompileCommands ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,15 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
   ERROR_STRIP_TRAILING_WHITESPACE
 )
-
+# FetchContent_Declare(
+#   z3
+#   URL "https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip"
+#   DOWNLOAD_EXTRACT_TIMESTAMP 1
+# )
 FetchContent_Declare(
   svf
-  GIT_REPOSITORY  "https://github.com/arcana-lab/SVF.git"
-  GIT_TAG         noelle-14
+  URL "https://github.com/arcana-lab/SVF/releases/download/v2.9-noelle-14/svf-v2.9_x86_64.tar.gz"
+  DOWNLOAD_EXTRACT_TIMESTAMP 1
 )
 FetchContent_Declare(
   scaf
@@ -85,13 +89,19 @@ set(LLVM_ENABLE_UNWIND_TABLES ON)
 if(NOELLE_SVF STREQUAL ON)
   set(NOELLE_SVF ON)
   list(APPEND NOELLE_CXX_FLAGS "-DNOELLE_ENABLE_SVF")
-  FetchContent_Populate(svf)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env LLVM_DIR=${LLVM_DIR} bash build.sh ${CMAKE_INSTALL_PREFIX}
-    RESULT_VARIABLE CMD_ERROR
-    WORKING_DIRECTORY ${svf_SOURCE_DIR}
+  # FetchContent_MakeAvailable(z3)
+  # FetchContent_GetProperties(z3)
+  # install(
+  #   PROGRAMS ${z3_SOURCE_DIR}/bin/libz3.so
+  #   DESTINATION lib
+  # )
+  FetchContent_MakeAvailable(svf)
+  FetchContent_GetProperties(svf)
+  install(
+    DIRECTORY ${svf_SOURCE_DIR}/lib
+    DESTINATION .
   )
-  include_directories(${CMAKE_INSTALL_PREFIX}/include/svf)
+  include_directories(${svf_SOURCE_DIR}/include/svf)
 endif()
 
 if(NOELLE_SCAF STREQUAL ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
   ERROR_STRIP_TRAILING_WHITESPACE
 )
-# FetchContent_Declare(
-#   z3
-#   URL "https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip"
-#   DOWNLOAD_EXTRACT_TIMESTAMP 1
-# )
+
 FetchContent_Declare(
   svf
   URL "https://github.com/arcana-lab/SVF/releases/download/v2.9-noelle-14/svf-v2.9_x86_64.tar.gz"
@@ -89,12 +85,6 @@ set(LLVM_ENABLE_UNWIND_TABLES ON)
 if(NOELLE_SVF STREQUAL ON)
   set(NOELLE_SVF ON)
   list(APPEND NOELLE_CXX_FLAGS "-DNOELLE_ENABLE_SVF")
-  # FetchContent_MakeAvailable(z3)
-  # FetchContent_GetProperties(z3)
-  # install(
-  #   PROGRAMS ${z3_SOURCE_DIR}/bin/libz3.so
-  #   DESTINATION lib
-  # )
   FetchContent_MakeAvailable(svf)
   FetchContent_GetProperties(svf)
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,8 @@ execute_process(
 
 FetchContent_Declare(
   svf
-  URL "https://github.com/arcana-lab/SVF/releases/download/v2.9-noelle-14/svf-v2.9_x86_64.tar.gz"
-  DOWNLOAD_EXTRACT_TIMESTAMP 1
+  GIT_REPOSITORY  "https://github.com/arcana-lab/SVF.git"
+  GIT_TAG         noelle-14-wip
 )
 FetchContent_Declare(
   scaf
@@ -87,11 +87,13 @@ if(NOELLE_SVF STREQUAL ON)
   list(APPEND NOELLE_CXX_FLAGS "-DNOELLE_ENABLE_SVF")
   FetchContent_MakeAvailable(svf)
   FetchContent_GetProperties(svf)
-  install(
-    DIRECTORY ${svf_SOURCE_DIR}/lib
-    DESTINATION .
+  include_directories(${svf_BINARY_DIR}/include)
+  include_directories(${svf_SOURCE_DIR}/svf/include)
+  include_directories(${svf_SOURCE_DIR}/svf-llvm/include)
+  set_property(
+    DIRECTORY ${svf_SOURCE_DIR}
+    PROPERTY CMAKE_BUILD_TYPE RelWithDebInfo
   )
-  include_directories(${svf_SOURCE_DIR}/include/svf)
 endif()
 
 if(NOELLE_SCAF STREQUAL ON)
@@ -100,6 +102,10 @@ if(NOELLE_SCAF STREQUAL ON)
   FetchContent_MakeAvailable(scaf)
   FetchContent_GetProperties(scaf)
   include_directories(${scaf_SOURCE_DIR}/include)
+  set_property(
+    DIRECTORY ${scaf_SOURCE_DIR}
+    PROPERTY CMAKE_BUILD_TYPE RelWithDebInfo
+  )
 endif()
 
 file(READ ${NOELLE_CMAKE_ROOT}/VERSION NOELLE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ compile: build
 build:
 	cmake -S . -B $(BUILD_DIR) -G "$(GENERATOR)" \
 		-DCMAKE_INSTALL_MESSAGE=LAZY \
+		-DBUILD_SHARED_LIBS=On \
+		-DSVF_ENABLE_ASSERTIONS=true \
 		-DCMAKE_INSTALL_PREFIX=install
 
 tests: install

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -55,7 +55,6 @@ endif()
 
 if(NOELLE_SVF STREQUAL "ON")
   list(APPEND noelle_load_SVF_LIBS
-    "-load ${CMAKE_INSTALL_PREFIX}/lib/libz3.so"
     "-load ${CMAKE_INSTALL_PREFIX}/lib/SvfLLVM.so"
   )
   list(APPEND noelle_load_SVF_PASS -noelle-svf)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+include(AddLLVM)
+include(HandleLLVMOptions)
+
 add_subdirectory(core)
 
 if(NOELLE_TOOLS STREQUAL ON)


### PR DESCRIPTION
- [x] Build, compilation and installation don't trigger unnecessary recompilations
- [x] Noelle doesn't refer to z3 in any way
- [ ] Extensive test

Now we need to enable z3 with `source /project/extra/z3/4.13.0/enable`