### PR TITLE
Supporting compilation with different build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,20 @@ if(DEFINED NOELLE_INSTALL_DIR)
   set(CMAKE_INSTALL_PREFIX ${NOELLE_INSTALL_DIR})
 endif()
 
-set(NOELLE_CXX_FLAGS 
-  -O0
-  -g
-  -fPIC
-  -std=c++17
-  -Wall
-)
+if(NOT DEFINED NOELLE_BUILD_TYPE)
+  set(NOELLE_BUILD_TYPE "Debug")
+endif()
+
+if(NOT DEFINED SVF_BUILD_TYPE)
+  set(SVF_BUILD_TYPE "Release")
+endif()
+
+if(NOT DEFINED SCAF_BUILD_TYPE)
+  set(SCAF_BUILD_TYPE "Release")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(LLVM 14 REQUIRED CONFIG)
 
@@ -63,6 +70,9 @@ function(noelle_acquire_option OPT)
 endfunction()
 
 message(STATUS "${Purple}Install directory${ColorReset} is ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "${Purple}NOELLE build type${ColorReset} is ${NOELLE_BUILD_TYPE}")
+message(STATUS "${Purple}SVF build type${ColorReset} is ${SVF_BUILD_TYPE}")
+message(STATUS "${Purple}SCAF build type${ColorReset} is ${SCAF_BUILD_TYPE}")
 
 noelle_acquire_option(NOELLE_SVF)
 noelle_acquire_option(NOELLE_SCAF)
@@ -70,11 +80,10 @@ noelle_acquire_option(NOELLE_AUTOTUNER)
 noelle_acquire_option(NOELLE_REPL)
 noelle_acquire_option(NOELLE_TOOLS)
 
-set(LLVM_ENABLE_UNWIND_TABLES ON)
-
 if(NOELLE_SVF STREQUAL ON)
   set(NOELLE_SVF ON)
   list(APPEND NOELLE_CXX_FLAGS "-DNOELLE_ENABLE_SVF")
+  set(CMAKE_BUILD_TYPE ${SVF_BUILD_TYPE})
   FetchContent_MakeAvailable(svf)
   FetchContent_GetProperties(svf)
   include_directories(${svf_BINARY_DIR}/include)
@@ -85,14 +94,13 @@ endif()
 if(NOELLE_SCAF STREQUAL ON)
   list(APPEND NOELLE_CXX_FLAGS "-DNOELLE_ENABLE_SCAF")
   option(ENABLE_SPECULATION "SCAF speculation" OFF)
+  set(CMAKE_BUILD_TYPE ${SCAF_BUILD_TYPE})
   FetchContent_MakeAvailable(scaf)
   FetchContent_GetProperties(scaf)
   include_directories(${scaf_SOURCE_DIR}/include)
-  set_property(
-    DIRECTORY ${scaf_SOURCE_DIR}
-    PROPERTY CMAKE_BUILD_TYPE RelWithDebInfo
-  )
 endif()
+
+set(CMAKE_BUILD_TYPE ${NOELLE_BUILD_TYPE})
 
 file(READ ${NOELLE_CMAKE_ROOT}/VERSION NOELLE_VERSION)
 string(STRIP ${NOELLE_VERSION} NOELLE_VERSION)

--- a/Kconfig
+++ b/Kconfig
@@ -21,3 +21,15 @@ config NOELLE_AUTOTUNER
 config NOELLE_REPL
   bool "Build the Noelle REPL tool"
   default n
+
+config NOELLE_BUILD_TYPE
+  string "Set build type for NOELLE"
+  default "Debug"
+
+config SVF_BUILD_TYPE
+  string "Set build type for SVF"
+  default "Release"
+
+config SCAF_BUILD_TYPE
+  string "Set build type for SCAF"
+  default "Release"

--- a/bin/noelle-config.in
+++ b/bin/noelle-config.in
@@ -4,23 +4,26 @@ function show_help() {
   echo "usage: $(basename $0) <OPTIONS>..."
   echo
   echo "Options"
-  echo "  --help              Print this help message"
-  echo "  --flags             Print the options used during compilation"
-  echo "  --prefix            Print the installation directory path"
-  echo "  --version           Print the library version"
-  echo "  --include           Print the include directory"
-  echo "  --core-libs         Print the shared libraries used by the NOELLE core"
-  echo "  --tool-libs         Print the shared libraries of the NOELLE tools"
-  echo "  --svf-libs          Print the shared libraries used by SVF"
-  echo "  --scaf-libs         Print the shared libraries used by SCAF"
-  echo "  --svf-analyses      Print the default SVF analyses used by default"
-  echo "  --scaf-analyses     Print the default SCAF analyses used by default"
-  echo "  --llvm-analyses     Print the default LLVM analyses used by default"
-  echo "  --git-commit        Print the git commit hash used at compilation time"
-  echo "  --git-origin        Print the git origin used during compilation"
-  echo "  --llvm-build        Print the build type of the specific LLVM used by NOELLE"
-  echo "  --llvm-prefix       Print the installation prefix of the specific LLVM used by NOELLE"
-  echo "  --llvm-version      Print the version of the specific LLVM used by NOELLE"
+  echo "  --help                Print this help message"
+  echo "  --flags               Print the options used during compilation"
+  echo "  --prefix              Print the installation directory path"
+  echo "  --version             Print the library version"
+  echo "  --include             Print the include directory"
+  echo "  --noelle-build-type   Print the build type used for Noelle. E.g. Debug"
+  echo "  --svf-build-type      Print the build type used for SVF. E.g. Release"
+  echo "  --scaf-build-type     Print the build type used for SCAF. E.g. Release"
+  echo "  --core-libs           Print the shared libraries used by the NOELLE core"
+  echo "  --tool-libs           Print the shared libraries of the NOELLE tools"
+  echo "  --svf-libs            Print the shared libraries used by SVF"
+  echo "  --scaf-libs           Print the shared libraries used by SCAF"
+  echo "  --svf-analyses        Print the default SVF analyses used by default"
+  echo "  --scaf-analyses       Print the default SCAF analyses used by default"
+  echo "  --llvm-analyses       Print the default LLVM analyses used by default"
+  echo "  --git-commit          Print the git commit hash used at compilation time"
+  echo "  --git-origin          Print the git origin used during compilation"
+  echo "  --llvm-build          Print the build type of the specific LLVM used by NOELLE"
+  echo "  --llvm-prefix         Print the installation prefix of the specific LLVM used by NOELLE"
+  echo "  --llvm-version        Print the version of the specific LLVM used by NOELLE"
 }
 
 if [[ $# < 1 ]]; then
@@ -42,6 +45,15 @@ for arg in "$@"; do
       ;;
     --version)
       echo "@NOELLE_VERSION@"
+      ;;
+    --noelle-build-type)
+      echo "@NOELLE_BUILD_TYPE@"
+      ;;
+    --svf-build-type)
+      echo "@SVF_BUILD_TYPE@"
+      ;;
+    --scaf-build-type)
+      echo "@SCAF_BUILD_TYPE@"
       ;;
     --include)
       echo "@CMAKE_INSTALL_PREFIX@/include"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(AddLLVM)
 include(HandleLLVMOptions)
+set(LLVM_ENABLE_UNWIND_TABLES ON)
 
 add_subdirectory(core)
 


### PR DESCRIPTION
This allows users to compile Noelle, SVF and SCAF through different cmake build types (e.g. Debug, Release, RelWithDebInfo)
- [x] Different build types
- [x] `noelle-config` can print these configurations