### PR TITLE
[doc] z3 as a prerequisite + Zythos instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ This is the status of NOELLE for different LLVM versions.
 
 
 ## Prerequisites
-LLVM 14.0.6
+- LLVM 14.0.6
+- Z3 4.8.8 or newer
 
 ### Northwestern users
-Those who have access to the [Zythos](https://users.cs.northwestern.edu/~simonec/files/Research/manuals/Zythos_guide.pdf) cluster at Northwestern can source LLVM 14.0.6 from any node of the cluster with:
+Those who have access to the [Zythos](https://users.cs.northwestern.edu/~simonec/files/Research/manuals/Zythos_guide.pdf) cluster at Northwestern can source LLVM 14.0.6 and Z3 4.13.0 from any node of the cluster with:
 ```
 source /project/extra/llvm/14.0.6/enable
+source /project/extra/z3/4.13.0/enable
 ```
 
 


### PR DESCRIPTION
When building NOELLE for v14 for the first time, cmake couldn't find z3. I fixed this by enabling z3, which I only knew to do from reading #157. That instruction should be somewhere more visible.

The error:
```
CMake Error at build/_deps/svf-src/CMakeLists.txt:115 (find_package):
  Could not find a package configuration file provided by "Z3" with any of
  the following names:

    Z3Config.cmake
    z3-config.cmake

  Add the installation prefix of "Z3" to CMAKE_PREFIX_PATH or set "Z3_DIR" to
  a directory containing one of the above files.  If "Z3" provides a separate
  development package or SDK, be sure it has been installed.


-- Configuring incomplete, errors occurred!
make: *** [Makefile:17: build] Error 1
```
