### PR TITLE
Fixed compile warnings

### DIFF
--- a/src/core/ldg_generator/src/LoopAwareMemDepAnalysis.cpp
+++ b/src/core/ldg_generator/src/LoopAwareMemDepAnalysis.cpp
@@ -28,9 +28,13 @@
  * SCAF headers
  */
 #ifdef NOELLE_ENABLE_SCAF
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wreorder"
+#  pragma GCC diagnostic ignored "-Wsuggest-override"
 #  include "scaf/MemoryAnalysisModules/LoopAA.h"
 #  include "scaf/Utilities/PDGQueries.h"
 #  include "scaf/Utilities/ModuleLoops.h"
+#  pragma GCC diagnostic pop
 #endif
 
 namespace arcana::noelle {

--- a/src/core/loop_iteration_space_analysis/src/LoopIterationSpaceAnalysis.cpp
+++ b/src/core/loop_iteration_space_analysis/src/LoopIterationSpaceAnalysis.cpp
@@ -918,14 +918,6 @@ bool LoopIterationSpaceAnalysis::isInnerDimensionSubscriptsBounded(
     return false;
   }
 
-  auto equalPred = ICmpInst::Predicate::ICMP_EQ;
-  auto strictUpperBoundPred = ICmpInst::Predicate::ICMP_SLT;
-  auto strictLowerBoundPred = ICmpInst::Predicate::ICMP_SGT;
-  auto looseUpperBoundPred =
-      CmpInst::getNonStrictPredicate(strictUpperBoundPred);
-  auto looseLowerBoundPred =
-      CmpInst::getNonStrictPredicate(strictLowerBoundPred);
-
   auto scevsMatch = [](const SCEV *scev1, const SCEV *scev2) -> bool {
     if (scev1 == scev2)
       return true;
@@ -976,7 +968,6 @@ bool LoopIterationSpaceAnalysis::isInnerDimensionSubscriptsBounded(
 
     auto zeroConstant =
         (ConstantInt *)ConstantInt::get(subscriptType, (int64_t)0);
-    auto zeroSCEV = SE.getConstant(zeroConstant);
 
     // sizeSCEV->print(errs() << "Checking if bounded by 0 and ");
     // subscriptSCEV->print(errs() << ", Subscript " << i << ": ");
@@ -1005,7 +996,6 @@ bool LoopIterationSpaceAnalysis::isInnerDimensionSubscriptsBounded(
        * If the step recurrence is negative and the AddRecExpr starts at the
        * size - 1, it is bounded
        */
-      auto startSCEV = subscriptRecSCEV->getStart();
       auto stepSCEV = subscriptRecSCEV->getStepRecurrence(SE);
       auto constantStepSCEV = dyn_cast<SCEVConstant>(stepSCEV);
       if (constantStepSCEV && constantStepSCEV->getValue()->isNegative()) {

--- a/src/core/loop_iteration_space_analysis/src/LoopIterationSpaceAnalysis.cpp
+++ b/src/core/loop_iteration_space_analysis/src/LoopIterationSpaceAnalysis.cpp
@@ -966,9 +966,6 @@ bool LoopIterationSpaceAnalysis::isInnerDimensionSubscriptsBounded(
       return false;
     }
 
-    auto zeroConstant =
-        (ConstantInt *)ConstantInt::get(subscriptType, (int64_t)0);
-
     // sizeSCEV->print(errs() << "Checking if bounded by 0 and ");
     // subscriptSCEV->print(errs() << ", Subscript " << i << ": ");
     // inst->print(errs() << "\tInst: ");

--- a/src/core/loop_sccdag_attributes/src/SCCDAGAttrs.cpp
+++ b/src/core/loop_sccdag_attributes/src/SCCDAGAttrs.cpp
@@ -571,7 +571,9 @@ std::tuple<bool, Value *, Value *, Value *, Value *> SCCDAGAttrs::
     Value *initialValue;
     Value *period;
     Value *step;
-    Value *accumulator = nullptr; //should be nullptr at return unless the Periodic Variable contains 2+ PHINodes. Identifies accumulator
+    Value *accumulator =
+        nullptr; // should be nullptr at return unless the Periodic Variable
+                 // contains 2+ PHINodes. Identifies accumulator
 
     auto from = edge->getSrc();
     auto to = edge->getDst();
@@ -584,16 +586,17 @@ std::tuple<bool, Value *, Value *, Value *, Value *> SCCDAGAttrs::
     if (toPHI->getNumIncomingValues() != 2)
       return notPeriodic;
 
-    /* 
-     * A different way of expressing a subtract-from-zero flipflop (which can be seen as "x = -x" at the C level)
-     * is to use two PHINode instructions.
-     * With two PHINodes, this can be written as phi1=(preheader, -x)(latch, phi2), phi2=(preheader, x)(latch, phi1)
-     * In such a case, only one of the phis should have scc-external users.
-     * The other phi should only be holding the "out of phase" value.
-     * If instead the other phi has scc-external users, it implies that the scc is composed
-     * of two interdependent variables rather than merely being another way of writing "x = -x."
+    /*
+     * A different way of expressing a subtract-from-zero flipflop (which can be
+     * seen as "x = -x" at the C level) is to use two PHINode instructions. With
+     * two PHINodes, this can be written as phi1=(preheader, -x)(latch, phi2),
+     * phi2=(preheader, x)(latch, phi1) In such a case, only one of the phis
+     * should have scc-external users. The other phi should only be holding the
+     * "out of phase" value. If instead the other phi has scc-external users, it
+     * implies that the scc is composed of two interdependent variables rather
+     * than merely being another way of writing "x = -x."
      */
-    if(isa<PHINode>(from)) {
+    if (isa<PHINode>(from)) {
 
       auto fromPHI = cast<PHINode>(from);
       bool fromHasExternalUsers = false;
@@ -603,7 +606,7 @@ std::tuple<bool, Value *, Value *, Value *, Value *> SCCDAGAttrs::
           continue;
         }
 
-        if (const auto &userInst = dyn_cast<Instruction>(usr)) {
+        if (isa<Instruction>(usr)) {
           fromHasExternalUsers = true;
         }
       }
@@ -612,7 +615,7 @@ std::tuple<bool, Value *, Value *, Value *, Value *> SCCDAGAttrs::
           continue;
         }
 
-        if (const auto &userInst = dyn_cast<Instruction>(usr)) {
+        if (isa<Instruction>(usr)) {
           toHasExternalUsers = true;
         }
       }
@@ -642,7 +645,6 @@ std::tuple<bool, Value *, Value *, Value *, Value *> SCCDAGAttrs::
       auto secondaryInitialConstantInt =
           dyn_cast<ConstantInt>(secondaryInitialValue);
       if (initialConstantInt && secondaryInitialConstantInt) {
-        auto c = initialConstantInt->isNegative() ? 1 : -1;
         step = llvm::ConstantExpr::getSub(secondaryInitialConstantInt,
                                           initialConstantInt);
       } else {

--- a/src/core/pdg_generator/src/IntegrationWithSVF.cpp
+++ b/src/core/pdg_generator/src/IntegrationWithSVF.cpp
@@ -28,6 +28,11 @@
  * SVF headers
  */
 #ifdef NOELLE_ENABLE_SVF
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  pragma GCC diagnostic ignored "-Wreorder"
+#  pragma GCC diagnostic ignored "-Wsuggest-override"
+#  pragma GCC diagnostic ignored "-Wuninitialized"
 #  include "Util/Options.h"
 #  include "SVF-LLVM/LLVMModule.h"
 #  include "SVF-LLVM/SVFIRBuilder.h"
@@ -38,6 +43,7 @@
 #  include "Graphs/PTACallGraph.h"
 #  include "Graphs/ICFG.h"
 #  include "MSSA/MemSSA.h"
+#  pragma GCC diagnostic pop
 #endif
 
 namespace arcana::noelle {

--- a/src/core/unique_ir_marker/include/arcana/noelle/core/IDToValueMapper.hpp
+++ b/src/core/unique_ir_marker/include/arcana/noelle/core/IDToValueMapper.hpp
@@ -17,9 +17,9 @@ public:
   void visitInstruction(Instruction &I);
 
 private:
+  Module &Mod;
   std::set<IDType> *relevantIDs;
   std::map<IDType, Instruction *> *mapping;
-  Module &Mod;
 };
 
 class IDToFunctionMapper : public InstVisitor<IDToFunctionMapper> {
@@ -32,9 +32,9 @@ public:
   void visitFunction(Function &I);
 
 private:
+  Module &Mod;
   std::set<IDType> *relevantIDs;
   std::map<IDType, Function *> *mapping;
-  Module &Mod;
 };
 
 } // namespace arcana::noelle

--- a/src/core/unique_ir_marker/include/arcana/noelle/core/UniqueIRMarker.hpp
+++ b/src/core/unique_ir_marker/include/arcana/noelle/core/UniqueIRMarker.hpp
@@ -26,13 +26,12 @@ public:
 private:
   IDType uniqueInstructionCounter();
   IDType uniqueModuleCounter();
-
-  IDType BasicBlockCounter, InstructionCounter, FunctionCounter, LoopCounter,
-      ModuleCounter;
   MDNode *buildNode(LLVMContext &, IDType);
-  ModulePass &MP;
 
+  ModulePass &MP;
   MarkerMode Mode;
+  IDType BasicBlockCounter, FunctionCounter, InstructionCounter, LoopCounter,
+      ModuleCounter;
 };
 
 } // namespace arcana::noelle

--- a/src/core/unique_ir_marker/src/UniqueIRMarker.cpp
+++ b/src/core/unique_ir_marker/src/UniqueIRMarker.cpp
@@ -132,9 +132,9 @@ MDNode *UniqueIRMarker::buildNode(LLVMContext &C, IDType value) {
 UniqueIRMarker::UniqueIRMarker(ModulePass &MP, MarkerMode mode)
   : MP(MP),
     Mode(mode),
-    InstructionCounter(0),
-    FunctionCounter(0),
     BasicBlockCounter(0),
+    FunctionCounter(0),
+    InstructionCounter(0),
     LoopCounter(0),
     ModuleCounter(0) {}
 

--- a/src/core/unique_ir_marker/src/UniqueIRVerifier.cpp
+++ b/src/core/unique_ir_marker/src/UniqueIRVerifier.cpp
@@ -12,7 +12,7 @@ void UniqueIRVerifier::visitModule(Module &M) {
   assert(metaNode->getNumOperands() == 1
          && "A Module which has been marked must have a VIAModule marker");
   auto setModuleID = UniqueIRMarkerReader::getModuleID(addressof(M));
-  assert(setModuleID && setModuleID.value() >= 0);
+  assert(setModuleID.has_value());
 }
 
 void UniqueIRVerifier::visitFunction(Function &F) {

--- a/src/tools/pdg_stats/src/PDGStats.cpp
+++ b/src/tools/pdg_stats/src/PDGStats.cpp
@@ -104,9 +104,7 @@ bool PDGStats::runOnModule(Module &M) {
 }
 
 void PDGStats::collectStatsForNodes(Function &F) {
-  for (auto &arg : F.args()) {
-    this->numberOfNodes++;
-  }
+  this->numberOfNodes += F.arg_size();
   for (auto &B : F) {
     this->numberOfNodes += B.size();
   }

--- a/src/tools/scev_simplification/src/SCEVSimplification.cpp
+++ b/src/tools/scev_simplification/src/SCEVSimplification.cpp
@@ -245,7 +245,7 @@ const SCEV *SCEVSimplification::getOffsetBetween(ScalarEvolution &SE,
     return nullptr;
   auto lhs = addSCEV->getOperand(0);
   auto rhs = addSCEV->getOperand(1);
-  if (!(lhs == startSCEV ^ rhs == startSCEV))
+  if (!((lhs == startSCEV) ^ (rhs == startSCEV)))
     return nullptr;
 
   auto offset = lhs == startSCEV ? rhs : lhs;


### PR DESCRIPTION
All warnings originating from Noelle have been addressed.
Most of warnings however, come from SVF and SCAF. Since Noelle uses a specified branch for both SVF and SCAF, I added pragma diagnostics to suppress the known warnings originating from them.
There should be only one (spurious) warning in SCAF when compiling with clang 14.0.6.

This PR has been tested through Gino's [PR22](https://github.com/arcana-lab/gino/pull/22)