### PR TITLE
Tool: `noelle-ldg-dot`

### DIFF
--- a/bin/tools/CMakeLists.txt
+++ b/bin/tools/CMakeLists.txt
@@ -3,6 +3,7 @@ install(
     noelle-codesize
     noelle-deadcode
     noelle-fixedpoint
+    noelle-ldg-dot
     noelle-loop-size
     noelle-loop-stats
     noelle-meta-loop-clean

--- a/bin/tools/noelle-ldg-dot
+++ b/bin/tools/noelle-ldg-dot
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+trap 'echo "error: $(basename $0): line $LINENO"; exit 1' ERR
+
+installDir=$(noelle-config --prefix)
+
+usage () {
+  echo "USAGE: `basename $0` INPUT_BC [OPTION]..."
+  echo
+  echo "Export the Dependence Graph of a loop to DOT graph."
+  echo
+  echo "Options:"
+  noelle-load -load $installDir/lib/LDGDot.so --help | grep "ldg-dot"
+}
+
+if test $# -lt 1 ; then
+  usage
+  exit 1
+fi
+
+for arg in "$@"; do
+  case ${arg} in
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      ;;
+  esac
+done
+
+noelle-load -load $installDir/lib/LDGDot.so -LDGDot -disable-output $@

--- a/src/tools/ldg_dot/CMakeLists.txt
+++ b/src/tools/ldg_dot/CMakeLists.txt
@@ -1,0 +1,25 @@
+FetchContent_Declare(
+  leptoinst
+  GIT_REPOSITORY  "https://github.com/fsossai/lepto-inst.git"
+)
+FetchContent_GetProperties(leptoinst)
+
+if(NOT rapidjson_POPULATED)
+  FetchContent_Populate(rapidjson)
+endif()
+
+if(NOT lepto_POPULATED)
+  FetchContent_Populate(leptoinst)
+endif()
+
+include_directories(${leptoinst_SOURCE_DIR}/include)
+
+noelle_tool_declare(LDGDot)
+target_sources(
+  LDGDot
+  PRIVATE
+  src/LDGDot.cpp
+  src/Pass.cpp
+  ${leptoinst_SOURCE_DIR}/src/LeptoInstVisitor.cpp
+)
+

--- a/src/tools/ldg_dot/src/LDGDot.cpp
+++ b/src/tools/ldg_dot/src/LDGDot.cpp
@@ -199,10 +199,10 @@ void exportToDotGraph(LoopContent *LC,
         if (dep->isLoopCarriedDependence()) {
           if (isa<LoopCarriedUnknownSCC>(genericSCC)) {
             if (DA && !DA->canThisDependenceBeLoopCarried(dep, *LS)) {
-              // terminable
+              // breakable
               edge["@COLOR@"] = "orange";
             } else {
-              // non-terminable
+              // non-breakable
               edge["@COLOR@"] = "red";
             }
           } else {

--- a/src/tools/ldg_dot/src/LDGDot.cpp
+++ b/src/tools/ldg_dot/src/LDGDot.cpp
@@ -1,0 +1,247 @@
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#include "llvm/IR/Value.h"
+#include "arcana/noelle/core/DataDependence.hpp"
+#include "arcana/noelle/core/LoopCarriedSCC.hpp"
+#include "arcana/noelle/core/LoopCarriedUnknownSCC.hpp"
+#include "arcana/noelle/core/MemoryDependence.hpp"
+#include "arcana/noelle/core/Noelle.hpp"
+#include "arcana/noelle/core/SCCDAGAttrs.hpp"
+#include "LeptoInstVisitor.hpp"
+
+#include "LDGDot.hpp"
+
+using namespace std;
+using namespace llvm;
+
+namespace arcana::noelle {
+
+string patchTemplate(const string &templateStr,
+                     const map<string, string> &patches) {
+  string result = templateStr;
+  for (const auto &[oldStr, newStr] : patches) {
+    size_t pos = 0;
+    while ((pos = result.find(oldStr, pos)) != string::npos) {
+      result.replace(pos, oldStr.length(), newStr);
+      pos += newStr.length();
+    }
+  }
+  return result;
+}
+
+void emitDotFile(const string &dotContent, string outputFile) {
+  ofstream outputStream(outputFile);
+  assert(outputStream.is_open());
+  outputStream << dotContent;
+  outputStream.close();
+}
+
+string pointerToString(const Value *V) {
+  ostringstream oss;
+  oss << std::setw(8) << std::setfill('0') << std::hex
+      << reinterpret_cast<uintptr_t>(V);
+  return oss.str();
+}
+
+string SCCKindToString(GenericSCC::SCCKind type) {
+  switch (type) {
+    case GenericSCC::LOOP_CARRIED:
+      return "Loop Carried";
+    case GenericSCC::REDUCTION:
+      return "Reduction";
+    case GenericSCC::BINARY_REDUCTION:
+      return "Binary Reduction";
+    case GenericSCC::RECOMPUTABLE:
+      return "Recomputable";
+    case GenericSCC::SINGLE_ACCUMULATOR_RECOMPUTABLE:
+      return "Single Accumulator Recomputable";
+    case GenericSCC::INDUCTION_VARIABLE:
+      return "IV";
+    case GenericSCC::LINEAR_INDUCTION_VARIABLE:
+      return "Linear IV";
+    case GenericSCC::PERIODIC_VARIABLE:
+      return "Periodic Variable";
+    case GenericSCC::UNKNOWN_CLOSED_FORM:
+      return "Unknown Closed Form";
+    case GenericSCC::MEMORY_CLONABLE:
+      return "Memory Clonable";
+    case GenericSCC::STACK_OBJECT_CLONABLE:
+      return "Stack Object Clonable";
+    case GenericSCC::LOOP_ITERATION:
+      return "Loop Iteration";
+    case GenericSCC::LOOP_CARRIED_UNKNOWN:
+      return "";
+    default:
+      return to_string(type);
+  }
+}
+
+string fixEscapes(const string &str) {
+  string escaped;
+  for (char c : str) {
+    if (c == '"') {
+      escaped += "\\\""; // Add escaped double quote
+    } else if (c == '\\') {
+      escaped += "\\\\"; // Add escaped double quote
+    } else {
+      escaped += c;
+    }
+  }
+  return escaped;
+}
+
+void exportToDotGraph(LoopContent *LC,
+                      string outputFile,
+                      DotOptions options,
+                      DependenceAnalysis *DA) {
+
+  auto LS = LC->getLoopStructure();
+  auto SCCManager = LC->getSCCManager();
+  auto SCCDAG = SCCManager->getSCCDAG();
+
+  LeptoInstVisitor lepto;
+
+  string graphTemplate =
+      "digraph G {\n"
+      "graph [style=\"filled,rounded\", fillcolor=\"white\", layout=\"fdp\"]\n"
+      "node [color=\"transparent\", fontname=\"Verdana\"]\n"
+      "@SUBGRAPHS@\n"
+      "@EDGES@\n"
+      "}\n";
+  string subgraphTemplate = "subgraph cluster_scc@ID@ {\n"
+                            "\tlabel=\"@LABEL@\"\n"
+                            "\tcolor=\"@COLOR@\"\n"
+                            "@NODES@"
+                            "}\n";
+  string nodeTemplate = "\t@ID@ [label=\"@LABEL@\"]\n";
+  string edgeTemplate =
+      "\t@SRC@ -> @DST@ [color=\"@COLOR@\", style=\"@STYLE@\", arrowhead=\"@ARROWHEAD@\"]\n";
+
+  map<string, string> graph;
+  set<pair<Value *, Value *>> addedEdges;
+  unordered_set<Value *> addedNodes;
+  set<tuple<Value *, Value *, DataDependenceType>> a;
+
+  graph["@EDGES@"] = "";
+  int subgraphId = 0;
+
+  for (auto SCCNode : SCCDAG->getSCCs()) {
+    auto genericSCC = SCCManager->getSCCAttrs(SCCNode);
+    map<string, string> subgraph;
+    subgraph["@ID@"] = to_string(subgraphId);
+    subgraph["@LABEL@"] = SCCKindToString(genericSCC->getKind());
+    if (isa<LoopCarriedUnknownSCC>(genericSCC)) {
+      // unknown
+      subgraph["@COLOR@"] = "red";
+    } else {
+      // known
+      if (options & HIDE_KNOWN_SCCS) {
+        continue;
+      }
+      subgraph["@COLOR@"] = "green";
+    }
+    for (auto I : SCCNode->getInstructions()) {
+      map<string, string> node;
+      auto srcId = "i" + pointerToString(I);
+      node["@ID@"] = srcId;
+      node["@LABEL@"] = fixEscapes(lepto(*I));
+      subgraph["@NODES@"] += patchTemplate(nodeTemplate, node);
+      addedNodes.insert(I);
+    }
+    auto deps = SCCNode->getEdges();
+    for (auto dep : deps) {
+      map<string, string> node;
+      map<string, string> edge;
+      auto src = dep->getSrc();
+      auto dst = dep->getDst();
+      auto srcId = "i" + pointerToString(src);
+      auto dstId = "i" + pointerToString(dst);
+
+      edge["@SRC@"] = srcId;
+      edge["@DST@"] = dstId;
+
+      if (isa<ControlDependence<Value, Value>>(dep)) {
+        edge["@STYLE@"] = "dashed";
+        edge["@ARROWHEAD@"] = "normal";
+        edge["@COLOR@"] = "lightskyblue";
+      } else {
+        edge["@STYLE@"] = "solid";
+        auto DD = cast<DataDependence<Value, Value>>(dep);
+        if (options & COLLAPSE_EDGES) {
+          edge["@ARROWHEAD@"] = "none";
+        } else {
+          if (DD->isRAWDependence()) {
+            if (isa<MemoryDependence<Value, Value>>(dep)) {
+              edge["@ARROWHEAD@"] = "normal";
+            } else if (isa<VariableDependence<Value, Value>>(dep)) {
+              edge["@ARROWHEAD@"] = "empty";
+            }
+          } else if (DD->isWARDependence()) {
+            if (isa<MemoryDependence<Value, Value>>(dep)) {
+              edge["@ARROWHEAD@"] = "inv";
+            } else if (isa<VariableDependence<Value, Value>>(dep)) {
+              edge["@ARROWHEAD@"] = "invempty";
+            }
+          } else if (DD->isWAWDependence()) {
+            if (isa<MemoryDependence<Value, Value>>(dep)) {
+              edge["@ARROWHEAD@"] = "dot";
+            } else if (isa<VariableDependence<Value, Value>>(dep)) {
+              edge["@ARROWHEAD@"] = "odot";
+            }
+          }
+        }
+        if (dep->isLoopCarriedDependence()) {
+          if (isa<LoopCarriedUnknownSCC>(genericSCC)) {
+            if (DA && !DA->canThisDependenceBeLoopCarried(dep, *LS)) {
+              // terminable
+              edge["@COLOR@"] = "orange";
+            } else {
+              // non-terminable
+              edge["@COLOR@"] = "red";
+            }
+          } else {
+            edge["@COLOR@"] = "green";
+          }
+        } else {
+          edge["@COLOR@"] = "lightgrey";
+        }
+      }
+
+      bool add = true;
+      if (options & COLLAPSE_EDGES) {
+        if (addedEdges.find({ src, dst }) != addedEdges.end()
+            || addedEdges.find({ dst, src }) != addedEdges.end()) {
+          add = false;
+        }
+      }
+      if (options & ONLY_LC_EDGES) {
+        if (!dep->isLoopCarriedDependence()) {
+          add = false;
+        }
+      }
+      if (!(options & SHOW_CONTROL_DEPS)) {
+        if (isa<ControlDependence<Value, Value>>(dep)) {
+          add = false;
+        }
+      }
+      if (add) {
+        graph["@EDGES@"] += patchTemplate(edgeTemplate, edge);
+        addedEdges.insert({ src, dst });
+      }
+    }
+
+    graph["@SUBGRAPHS@"] += patchTemplate(subgraphTemplate, subgraph);
+    subgraphId++;
+  }
+
+  string dotContent = patchTemplate(graphTemplate, graph);
+  emitDotFile(dotContent, outputFile);
+}
+
+} // namespace arcana::noelle

--- a/src/tools/ldg_dot/src/LDGDot.hpp
+++ b/src/tools/ldg_dot/src/LDGDot.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+#include <arcana/noelle/core/Noelle.hpp>
+#include <arcana/noelle/core/DependenceAnalysis.hpp>
+
+namespace arcana::noelle {
+
+enum DotOptions_value {
+  DEFAULT = 0,
+  ONLY_LC_EDGES = 1 << 0,
+  HIDE_KNOWN_SCCS = 1 << 1,
+  COLLAPSE_EDGES = 1 << 2,
+  SHOW_CONTROL_DEPS = 1 << 3,
+};
+
+using DotOptions = unsigned int;
+
+/*
+ * The option `DA` allows for a custom dependence analysis to run on top of
+ * noelle predefined analyses. Any dependence disproved by `DA` will be marked
+ * with a different color (e.g. orange) in the file graph.
+ *
+ * If you intend to generate a graph where dependences dispoved by `DA` not
+ * shown then provide a LoopContent `LC` computed with `DA` and pass `nullptr`
+ * as `DA`. The resulting graph might me significatly different as SCC may now
+ * split because of a missing edge.
+ */
+void exportToDotGraph(noelle::LoopContent *LC,
+                      std::string outputFile,
+                      DotOptions options = DEFAULT,
+                      noelle::DependenceAnalysis *DA = nullptr);
+
+} // namespace arcana::noelle

--- a/src/tools/ldg_dot/src/Pass.cpp
+++ b/src/tools/ldg_dot/src/Pass.cpp
@@ -1,0 +1,109 @@
+#include <cstdint>
+#include <string>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Support/CommandLine.h"
+
+#include "arcana/noelle/core/Noelle.hpp"
+#include "arcana/noelle/core/NoellePass.hpp"
+
+#include "LDGDot.hpp"
+#include "Pass.hpp"
+
+using namespace std;
+using namespace llvm;
+
+namespace arcana::noelle {
+
+/*
+ * Options should starts with the same unique prefix (e.g. "ldg-dot-"), so that
+ * they can be grep'd from `opt --help with not collisions`. If other prefixes
+ * are used, the tool `noelle-ldg-dot` should be modified accordingly
+ */
+static cl::opt<uint64_t> OptLoopId("ldg-dot-loop-id",
+                                   cl::desc("Target loop ID"),
+                                   cl::Required);
+static cl::opt<string> OptOutputFile("ldg-dot-output-file",
+                                     cl::desc("Output file for the dot graph"));
+static cl::opt<bool> OptCollapseEdges(
+    "ldg-dot-collapse-edges",
+    cl::desc("Edges from and to the same node will be collapsed into one"));
+static cl::opt<bool> OptOnlyLCEdges(
+    "ldg-dot-only-lc-edges",
+    cl::desc("Show only loop-carried dependences"));
+static cl::opt<bool> OptCFG("ldg-dot-cfg",
+                            cl::desc("Show control dependences"));
+static cl::opt<bool> OptHideKnownSCCs(
+    "ldg-dot-hide-known-sccs",
+    cl::desc("Hide SCC that are not LoopCarriedUnknownSCC"));
+
+DotPass::DotPass() : ModulePass{ ID }, log(NoelleLumberjack, "LDGDot") {}
+
+bool DotPass::doInitialization(Module &M) {
+  return false;
+}
+
+void DotPass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<NoellePass>();
+}
+
+bool DotPass::runOnModule(Module &M) {
+  auto &noelle = getAnalysis<NoellePass>().getNoelle();
+  bool found = false;
+
+  if (OptLoopId.getNumOccurrences() > 0) {
+    auto &LSs = *noelle.getLoopStructures();
+    for (auto LS : LSs) {
+      if (LS->getID().value() == OptLoopId) {
+        runOnLoop(noelle, LS);
+        found = true;
+        break;
+      }
+    }
+  }
+
+  if (!found) {
+    log.bypass() << "ERROR: target loop not found\n";
+  }
+
+  return false;
+}
+
+void DotPass::runOnLoop(Noelle &noelle, LoopStructure *LS) {
+  string outputFile;
+  if (OptOutputFile.getNumOccurrences() == 0) {
+    outputFile = "ldg_id_" + to_string(OptLoopId) + ".dot";
+  } else {
+    outputFile = OptOutputFile;
+  }
+
+  DotOptions options = 0;
+  if (OptCollapseEdges) {
+    options |= COLLAPSE_EDGES;
+  }
+  if (OptOnlyLCEdges) {
+    options |= ONLY_LC_EDGES;
+  }
+  if (OptHideKnownSCCs) {
+    options |= HIDE_KNOWN_SCCS;
+  }
+
+  auto optimizations = { LoopContentOptimization::MEMORY_CLONING_ID,
+                         LoopContentOptimization::THREAD_SAFE_LIBRARY_ID };
+  auto LC = noelle.getLoopContent(LS, optimizations);
+
+  exportToDotGraph(LC, outputFile, options);
+
+  log.bypass() << "Dot file written to " << outputFile << "\n";
+}
+
+char DotPass::ID = 0;
+static RegisterPass<DotPass> X("LDGDot",
+                               "Dumps loop SCCDAGs into Dot file",
+                               false,
+                               false);
+
+} // namespace arcana::noelle

--- a/src/tools/ldg_dot/src/Pass.hpp
+++ b/src/tools/ldg_dot/src/Pass.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "arcana/noelle/core/Noelle.hpp"
+#include "arcana/noelle/core/Lumberjack.hpp"
+
+namespace arcana::noelle {
+
+class DotPass : public llvm::ModulePass {
+public:
+  static char ID;
+
+  DotPass();
+  bool doInitialization(llvm::Module &M) override;
+  bool runOnModule(llvm::Module &M) override;
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+  void runOnLoop(noelle::Noelle &noelle, noelle::LoopStructure *LS);
+
+private:
+  noelle::Logger log;
+};
+
+} // namespace arcana::noelle


### PR DESCRIPTION
Convert a loop dependence graph into a [DOT graph](https://graphviz.org/doc/info/lang.html). Particular attention is put to SCCs and loop-carried dependences. 

This tool is intended to replace the cumbersome `noelle-pdg`.

- [x] Tool
- [x] [Wiki page](https://github.com/arcana-lab/noelle/wiki/LDGs-to-DOT-graphs)