### PR TITLE
Added `removeAnalysis` to `Noelle`

### DIFF
--- a/src/core/ldg_generator/include/arcana/noelle/core/LDGGenerator.hpp
+++ b/src/core/ldg_generator/include/arcana/noelle/core/LDGGenerator.hpp
@@ -38,6 +38,8 @@ public:
 
   void addAnalysis(DependenceAnalysis *a);
 
+  void removeAnalysis(DependenceAnalysis *a);
+
   bool areLoopDependenceAnalysesEnabled(void) const;
 
   void enableLoopDependenceAnalyses(bool enabled);

--- a/src/core/ldg_generator/src/LDGGenerator.cpp
+++ b/src/core/ldg_generator/src/LDGGenerator.cpp
@@ -196,6 +196,10 @@ void LDGGenerator::addAnalysis(DependenceAnalysis *a) {
   this->ddAnalyses.insert(a);
 }
 
+void LDGGenerator::removeAnalysis(DependenceAnalysis *a) {
+  this->ddAnalyses.erase(a);
+}
+
 PDG *LDGGenerator::generateLoopDependenceGraph(PDG *functionDG,
                                                ScalarEvolution &scalarEvolution,
                                                DominatorSummary &DS,

--- a/src/core/noelle/include/arcana/noelle/core/Noelle.hpp
+++ b/src/core/noelle/include/arcana/noelle/core/Noelle.hpp
@@ -204,6 +204,10 @@ public:
 
   void addAnalysis(CallGraphAnalysis *a);
 
+  void removeAnalysis(DependenceAnalysis *a);
+
+  void removeAnalysis(CallGraphAnalysis *a);
+
   PDG *getProgramDependenceGraph(void);
 
   DataFlowAnalysis getDataFlowAnalyses(void) const;

--- a/src/core/noelle/src/Noelle_dependences.cpp
+++ b/src/core/noelle/src/Noelle_dependences.cpp
@@ -100,4 +100,9 @@ void Noelle::addAnalysis(DependenceAnalysis *a) {
   return;
 }
 
+void Noelle::removeAnalysis(DependenceAnalysis *a) {
+  this->pdgGenerator.removeAnalysis(a);
+  this->ldgGenerator.removeAnalysis(a);
+}
+
 } // namespace arcana::noelle

--- a/src/core/noelle/src/Noelle_function.cpp
+++ b/src/core/noelle/src/Noelle_function.cpp
@@ -51,8 +51,10 @@ FunctionsManager *Noelle::getFunctionsManager(void) {
 
 void Noelle::addAnalysis(CallGraphAnalysis *a) {
   this->pdgGenerator.addAnalysis(a);
+}
 
-  return;
+void Noelle::removeAnalysis(CallGraphAnalysis *a) {
+  this->pdgGenerator.removeAnalysis(a);
 }
 
 } // namespace arcana::noelle

--- a/src/core/pdg_generator/include/arcana/noelle/core/PDGGenerator.hpp
+++ b/src/core/pdg_generator/include/arcana/noelle/core/PDGGenerator.hpp
@@ -58,6 +58,10 @@ public:
 
   void addAnalysis(CallGraphAnalysis *a);
 
+  void removeAnalysis(DependenceAnalysis *a);
+
+  void removeAnalysis(CallGraphAnalysis *a);
+
   PDG *getPDG(void);
 
   noelle::CallGraph *getProgramCallGraph(void);

--- a/src/core/pdg_generator/src/PDGGenerator.cpp
+++ b/src/core/pdg_generator/src/PDGGenerator.cpp
@@ -785,12 +785,18 @@ bool PDGGenerator::edgeIsAlongNonMemoryWritingFunctions(
 
 void PDGGenerator::addAnalysis(DependenceAnalysis *a) {
   this->ddAnalyses.insert(a);
+}
 
-  return;
+void PDGGenerator::removeAnalysis(DependenceAnalysis *a) {
+  this->ddAnalyses.erase(a);
 }
 
 void PDGGenerator::addAnalysis(CallGraphAnalysis *a) {
   this->cgAnalyses.insert(a);
+}
+
+void PDGGenerator::removeAnalysis(CallGraphAnalysis *a) {
+  this->cgAnalyses.erase(a);
 }
 
 PDGGenerator::~PDGGenerator() {


### PR DESCRIPTION
Custom `DependenceAnalysis`s can now be removed. This is for both symmetry with `addAnalysis` and is necessary when studying differences between analyses.